### PR TITLE
Feature/121 dataset get hazard curves wrapper

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.3
+current_version = 1.2.0
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>.*)-(?P<build>\d+))?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## [1.2.0] 2025-07-22
+
+### Added
+ - new function `toshi_hazard_store.query.datasets.get_hazard_curves` 
+   for compatibility with legacy dynamodb queries. [`#121](https://github.com/GNS-Science/toshi-hazard-store/issues/121)
+
 ## [1.1.3] 2025-07
 
 ## Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "toshi-hazard-store"
-version = "1.1.3"
+version = "1.2.0"
 
 homepage = "https://github.com/GNS-Science/toshi-hazard-store"
 description = "Library for saving and retrieving NZHSM openquake hazard results with convenience (uses AWS Dynamodb)."

--- a/tests/query/test_hazard_curve_migration.py
+++ b/tests/query/test_hazard_curve_migration.py
@@ -8,8 +8,6 @@ import pytest
 
 from toshi_hazard_store.query import datasets, hazard_query
 
-# import toshi_hazard_store.query.datasets
-
 fixture_path = pathlib.Path(__file__).parent.parent / 'fixtures' / 'query'
 
 

--- a/toshi_hazard_store/__init__.py
+++ b/toshi_hazard_store/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """GNS Science"""
 __email__ = 'chrisbc@artisan.co.nz'
-__version__ = '1.1.3'
+__version__ = '1.2.0'
 
 
 import toshi_hazard_store.model as model

--- a/toshi_hazard_store/query/datasets.py
+++ b/toshi_hazard_store/query/datasets.py
@@ -373,12 +373,21 @@ def get_hazard_curves(
     """
     Retrieves aggregated hazard curves from the dataset.
 
+    The optional `strategy` argument can be used to control how the query behaves:
+     - 'naive' (the default) lets pyarrow do its normal thing.
+     - 'd1' assumes the dataset is partitioned on `vs30`, generating multiple pyarrow queries from the user args.
+     - 'd2' assumes the dataset is partitioned on `vs30, nloc_0` and acts accordingly.
+
+    These overriding  strategies alow the user to tune the query to suit the size of the datasets and the
+    compute resources available. e.g. for the full NSHM, with an AWS lambda function, the `d2` option is optimal.
+
     Args:
       location_codes (list): List of location codes.
       vs30s (list): List of VS30 values.
       hazard_model: the hazard model id.
       aggs (list): List of aggregation types.
-      strategy: which query strategy to use.
+      strategy: which query strategy to use (options are `d1`, `d2`, `naive`).
+          Other values will use the `naive` strategy.
 
     Yields:
       AggregatedHazard: An object containing the aggregated hazard curve data.
@@ -390,9 +399,9 @@ def get_hazard_curves(
 
     count = 0
 
-    if strategy == "d2":  # pragma: no cover
+    if strategy == "d2":
         qfn = get_hazard_curves_by_vs30_nloc0
-    elif strategy == "d1":  # pragma: no cover
+    elif strategy == "d1":
         qfn = get_hazard_curves_by_vs30
     else:
         qfn = get_hazard_curves_naive


### PR DESCRIPTION
 - closing #121
 - migrates query wrapper from nshm-hazard-graphql-api for general users.
 - minor version bump as we're extending the query API.
 - improved typing on dataset modules function signatures.