### PR TITLE
extend test coverage on GH CI/CD

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.3
+current_version = 1.2.4
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>.*)-(?P<build>\d+))?

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,7 +17,7 @@ jobs:
   call-test-workflow:
     uses: GNS-Science/nshm-github-actions/.github/workflows/python-run-tests.yml@main
     with:
-      operating-systems: "['ubuntu-latest', 'macos-latest']"
-      python-versions: "['3.10', '3.11']"
+      operating-systems: "['ubuntu-latest', 'macos-latest, 'windows-latest']"
+      python-versions: "['3.10', '3.11', '3.12']"
       delete-poetry-lock:  true # ${{ github.event_name == 'schedule' }} # the scheduled build tests against newer dependencies
     secrets: inherit

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -17,7 +17,7 @@ jobs:
   call-test-workflow:
     uses: GNS-Science/nshm-github-actions/.github/workflows/python-run-tests.yml@main
     with:
-      operating-systems: "['ubuntu-latest', 'macos-latest, 'windows-latest']"
+      operating-systems: "['ubuntu-latest', 'macos-latest', 'windows-latest']"
       python-versions: "['3.10', '3.11', '3.12']"
       delete-poetry-lock:  true # ${{ github.event_name == 'schedule' }} # the scheduled build tests against newer dependencies
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [1.2.4] 2025-08
 ### Added
  - GHA tests: add python`3.12` and `windows-latest` to matrix.
+ - more test coverage on `pyarrow` package.
+
+### Changed
+ - fixed unlink bug
+ - minor test issues
 
 ## [1.2.3] 2025-08-15
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.2.4] 2025-08
+### Added
+ - GHA tests: add python`3.12` and `windows-latest` to matrix.
+
 ## [1.2.3] 2025-08-15
 ### Changed
  - HDF5 extraction uses OpenQuake logic tree API solving compatibility issue with openquake-engine>=3.21.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -1142,21 +1142,6 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
-name = "execnet"
-version = "2.1.1"
-description = "execnet: rapid multi-Python deployment"
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
-    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
-]
-
-[package.extras]
-testing = ["hatch", "pre-commit", "pytest", "tox"]
-
-[[package]]
 name = "executing"
 version = "2.2.0"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -4105,27 +4090,6 @@ files = [
 pytest = ">=7"
 
 [[package]]
-name = "pytest-xdist"
-version = "3.8.0"
-description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
-    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
-]
-
-[package.dependencies]
-execnet = ">=2.1"
-pytest = ">=7.0.0"
-
-[package.extras]
-psutil = ["psutil (>=3.0)"]
-setproctitle = ["setproctitle"]
-testing = ["filelock"]
-
-[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -5428,4 +5392,4 @@ openquake = ["fiona", "networkx", "numba", "openquake-engine"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "f754b4296453b54c8bb5b276621e5c319e85554dc4af04a8c10d07ce1d9b2988"
+content-hash = "af09522123802fb78a50ace004c459c38d86cc40c0678f2ea6c9d6a89811f251"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1142,6 +1142,21 @@ files = [
 test = ["pytest (>=6)"]
 
 [[package]]
+name = "execnet"
+version = "2.1.1"
+description = "execnet: rapid multi-Python deployment"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "execnet-2.1.1-py3-none-any.whl", hash = "sha256:26dee51f1b80cebd6d0ca8e74dd8745419761d3bef34163928cbebbdc4749fdc"},
+    {file = "execnet-2.1.1.tar.gz", hash = "sha256:5189b52c6121c24feae288166ab41b32549c7e2348652736540b9e6e7d4e72e3"},
+]
+
+[package.extras]
+testing = ["hatch", "pre-commit", "pytest", "tox"]
+
+[[package]]
 name = "executing"
 version = "2.2.0"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -3199,8 +3214,6 @@ markers = "extra == \"openquake\""
 files = [
     {file = "pillow-11.3.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:1b9c17fd4ace828b3003dfd1e30bff24863e0eb59b535e8f80194d9cc7ecf860"},
     {file = "pillow-11.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:65dc69160114cdd0ca0f35cb434633c75e8e7fad4cf855177a05bf38678f73ad"},
-    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7107195ddc914f656c7fc8e4a5e1c25f32e9236ea3ea860f257b0436011fddd0"},
-    {file = "pillow-11.3.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc3e831b563b3114baac7ec2ee86819eb03caa1a2cef0b481a5675b59c4fe23b"},
     {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f1f182ebd2303acf8c380a54f615ec883322593320a9b00438eb842c1f37ae50"},
     {file = "pillow-11.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4445fa62e15936a028672fd48c4c11a66d641d2c05726c7ec1f8ba6a572036ae"},
     {file = "pillow-11.3.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71f511f6b3b91dd543282477be45a033e4845a40278fa8dcdbfdb07109bf18f9"},
@@ -3210,8 +3223,6 @@ files = [
     {file = "pillow-11.3.0-cp310-cp310-win_arm64.whl", hash = "sha256:819931d25e57b513242859ce1876c58c59dc31587847bf74cfe06b2e0cb22d2f"},
     {file = "pillow-11.3.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:1cd110edf822773368b396281a2293aeb91c90a2db00d78ea43e7e861631b722"},
     {file = "pillow-11.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:9c412fddd1b77a75aa904615ebaa6001f169b26fd467b4be93aded278266b288"},
-    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1aa4de119a0ecac0a34a9c8bde33f34022e2e8f99104e47a3ca392fd60e37d"},
-    {file = "pillow-11.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:91da1d88226663594e3f6b4b8c3c8d85bd504117d043740a8e0ec449087cc494"},
     {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:643f189248837533073c405ec2f0bb250ba54598cf80e8c1e043381a60632f58"},
     {file = "pillow-11.3.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:106064daa23a745510dabce1d84f29137a37224831d88eb4ce94bb187b1d7e5f"},
     {file = "pillow-11.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:cd8ff254faf15591e724dc7c4ddb6bf4793efcbe13802a4ae3e863cd300b493e"},
@@ -3221,8 +3232,6 @@ files = [
     {file = "pillow-11.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:30807c931ff7c095620fe04448e2c2fc673fcbb1ffe2a7da3fb39613489b1ddd"},
     {file = "pillow-11.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fdae223722da47b024b867c1ea0be64e0df702c5e0a60e27daad39bf960dd1e4"},
     {file = "pillow-11.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:921bd305b10e82b4d1f5e802b6850677f965d8394203d182f078873851dada69"},
-    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb76541cba2f958032d79d143b98a3a6b3ea87f0959bbe256c0b5e416599fd5d"},
-    {file = "pillow-11.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:67172f2944ebba3d4a7b54f2e95c786a3a50c21b88456329314caaa28cda70f6"},
     {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97f07ed9f56a3b9b5f49d3661dc9607484e85c67e27f3e8be2c7d28ca032fec7"},
     {file = "pillow-11.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:676b2815362456b5b3216b4fd5bd89d362100dc6f4945154ff172e206a22c024"},
     {file = "pillow-11.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3e184b2f26ff146363dd07bde8b711833d7b0202e27d13540bfe2e35a323a809"},
@@ -3235,8 +3244,6 @@ files = [
     {file = "pillow-11.3.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:7859a4cc7c9295f5838015d8cc0a9c215b77e43d07a25e460f35cf516df8626f"},
     {file = "pillow-11.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec1ee50470b0d050984394423d96325b744d55c701a439d2bd66089bff963d3c"},
     {file = "pillow-11.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7db51d222548ccfd274e4572fdbf3e810a5e66b00608862f947b163e613b67dd"},
-    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2d6fcc902a24ac74495df63faad1884282239265c6839a0a6416d33faedfae7e"},
-    {file = "pillow-11.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f0f5d8f4a08090c6d6d578351a2b91acf519a54986c055af27e7a93feae6d3f1"},
     {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c37d8ba9411d6003bba9e518db0db0c58a680ab9fe5179f040b0463644bc9805"},
     {file = "pillow-11.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13f87d581e71d9189ab21fe0efb5a23e9f28552d5be6979e84001d3b8505abe8"},
     {file = "pillow-11.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:023f6d2d11784a465f09fd09a34b150ea4672e85fb3d05931d89f373ab14abb2"},
@@ -3246,8 +3253,6 @@ files = [
     {file = "pillow-11.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:1904e1264881f682f02b7f8167935cce37bc97db457f8e7849dc3a6a52b99580"},
     {file = "pillow-11.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:4c834a3921375c48ee6b9624061076bc0a32a60b5532b322cc0ea64e639dd50e"},
     {file = "pillow-11.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5e05688ccef30ea69b9317a9ead994b93975104a677a36a8ed8106be9260aa6d"},
-    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1019b04af07fc0163e2810167918cb5add8d74674b6267616021ab558dc98ced"},
-    {file = "pillow-11.3.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f944255db153ebb2b19c51fe85dd99ef0ce494123f21b9db4877ffdfc5590c7c"},
     {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f85acb69adf2aaee8b7da124efebbdb959a104db34d3a2cb0f3793dbae422a8"},
     {file = "pillow-11.3.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:05f6ecbeff5005399bb48d198f098a9b4b6bdf27b8487c7f38ca16eeb070cd59"},
     {file = "pillow-11.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:a7bc6e6fd0395bc052f16b1a8670859964dbd7003bd0af2ff08342eb6e442cfe"},
@@ -3257,8 +3262,6 @@ files = [
     {file = "pillow-11.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:8797edc41f3e8536ae4b10897ee2f637235c94f27404cac7297f7b607dd0716e"},
     {file = "pillow-11.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:d9da3df5f9ea2a89b81bb6087177fb1f4d1c7146d583a3fe5c672c0d94e55e12"},
     {file = "pillow-11.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0b275ff9b04df7b640c59ec5a3cb113eefd3795a8df80bac69646ef699c6981a"},
-    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0743841cabd3dba6a83f38a92672cccbd69af56e3e91777b0ee7f4dba4385632"},
-    {file = "pillow-11.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2465a69cf967b8b49ee1b96d76718cd98c4e925414ead59fdf75cf0fd07df673"},
     {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41742638139424703b4d01665b807c6468e23e699e8e90cffefe291c5832b027"},
     {file = "pillow-11.3.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:93efb0b4de7e340d99057415c749175e24c8864302369e05914682ba642e5d77"},
     {file = "pillow-11.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7966e38dcd0fa11ca390aed7c6f20454443581d758242023cf36fcb319b1a874"},
@@ -3268,8 +3271,6 @@ files = [
     {file = "pillow-11.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:155658efb5e044669c08896c0c44231c5e9abcaadbc5cd3648df2f7c0b96b9a6"},
     {file = "pillow-11.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:59a03cdf019efbfeeed910bf79c7c93255c3d54bc45898ac2a4140071b02b4ae"},
     {file = "pillow-11.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f8a5827f84d973d8636e9dc5764af4f0cf2318d26744b3d902931701b0d46653"},
-    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ee92f2fd10f4adc4b43d07ec5e779932b4eb3dbfbc34790ada5a6669bc095aa6"},
-    {file = "pillow-11.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c96d333dcf42d01f47b37e0979b6bd73ec91eae18614864622d9b87bbd5bbf36"},
     {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c96f993ab8c98460cd0c001447bff6194403e8b1d7e149ade5f00594918128b"},
     {file = "pillow-11.3.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:41342b64afeba938edb034d122b2dda5db2139b9a4af999729ba8818e0056477"},
     {file = "pillow-11.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:068d9c39a2d1b358eb9f245ce7ab1b5c3246c7c8c7d9ba58cfa5b43146c06e50"},
@@ -3279,8 +3280,6 @@ files = [
     {file = "pillow-11.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:79ea0d14d3ebad43ec77ad5272e6ff9bba5b679ef73375ea760261207fa8e0aa"},
     {file = "pillow-11.3.0-cp39-cp39-macosx_10_10_x86_64.whl", hash = "sha256:48d254f8a4c776de343051023eb61ffe818299eeac478da55227d96e241de53f"},
     {file = "pillow-11.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7aee118e30a4cf54fdd873bd3a29de51e29105ab11f9aad8c32123f58c8f8081"},
-    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:23cff760a9049c502721bdb743a7cb3e03365fafcdfc2ef9784610714166e5a4"},
-    {file = "pillow-11.3.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6359a3bc43f57d5b375d1ad54a0074318a0844d11b76abccf478c37c986d3cfc"},
     {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:092c80c76635f5ecb10f3f83d76716165c96f5229addbd1ec2bdbbda7d496e06"},
     {file = "pillow-11.3.0-cp39-cp39-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cadc9e0ea0a2431124cde7e1697106471fc4c1da01530e679b2391c37d3fbb3a"},
     {file = "pillow-11.3.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:6a418691000f2a418c9135a7cf0d797c1bb7d9a485e61fe8e7722845b95ef978"},
@@ -3290,15 +3289,11 @@ files = [
     {file = "pillow-11.3.0-cp39-cp39-win_arm64.whl", hash = "sha256:6abdbfd3aea42be05702a8dd98832329c167ee84400a1d1f61ab11437f1717eb"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3cee80663f29e3843b68199b9d6f4f54bd1d4a6b59bdd91bceefc51238bcb967"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b5f56c3f344f2ccaf0dd875d3e180f631dc60a51b314295a3e681fe8cf851fbe"},
-    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e67d793d180c9df62f1f40aee3accca4829d3794c95098887edc18af4b8b780c"},
-    {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d000f46e2917c705e9fb93a3606ee4a819d1e3aa7a9b442f6444f07e77cf5e25"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:527b37216b6ac3a12d7838dc3bd75208ec57c1c6d11ef01902266a5a0c14fc27"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be5463ac478b623b9dd3937afd7fb7ab3d79dd290a28e2b6df292dc75063eb8a"},
     {file = "pillow-11.3.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:8dc70ca24c110503e16918a658b869019126ecfe03109b754c402daff12b3d9f"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:7c8ec7a017ad1bd562f93dbd8505763e688d388cde6e4a010ae1486916e713e6"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:9ab6ae226de48019caa8074894544af5b53a117ccb9d3b3dcb2871464c829438"},
-    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe27fb049cdcca11f11a7bfda64043c37b30e6b91f10cb5bab275806c32f6ab3"},
-    {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:465b9e8844e3c3519a983d58b80be3f668e2a7a5db97f2784e7079fbc9f9822c"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5418b53c0d59b3824d05e029669efa023bbef0f3e92e75ec8428f3799487f361"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:504b6f59505f08ae014f724b6207ff6222662aab5cc9542577fb084ed0676ac7"},
     {file = "pillow-11.3.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:c84d689db21a1c397d001aa08241044aa2069e7587b398c8cc63020390b1c1b8"},
@@ -4108,6 +4103,27 @@ files = [
 
 [package.dependencies]
 pytest = ">=7"
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+description = "pytest xdist plugin for distributed testing, most importantly across multiple CPUs"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88"},
+    {file = "pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1"},
+]
+
+[package.dependencies]
+execnet = ">=2.1"
+pytest = ">=7.0.0"
+
+[package.extras]
+psutil = ["psutil (>=3.0)"]
+setproctitle = ["setproctitle"]
+testing = ["filelock"]
 
 [[package]]
 name = "python-dateutil"
@@ -5412,4 +5428,4 @@ openquake = ["fiona", "networkx", "numba", "openquake-engine"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "af09522123802fb78a50ace004c459c38d86cc40c0678f2ea6c9d6a89811f251"
+content-hash = "f754b4296453b54c8bb5b276621e5c319e85554dc4af04a8c10d07ce1d9b2988"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [tool.poetry]
 name = "toshi-hazard-store"
-version = "1.2.3"
+version = "1.2.4"
 
 homepage = "https://github.com/GNS-Science/toshi-hazard-store"
 description = "Library for saving and retrieving NZHSM openquake hazard results with convenience (uses AWS Dynamodb)."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ pytest-cov = "^6.0.0"
 pytest = ">=8"
 pytest-lazy-fixtures = "^1.1.2"
 flake8 = "^7.2.0"
-pytest-xdist = "^3.8.0"
 
 
 [tool.poetry.extras]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ pytest-cov = "^6.0.0"
 pytest = ">=8"
 pytest-lazy-fixtures = "^1.1.2"
 flake8 = "^7.2.0"
+pytest-xdist = "^3.8.0"
 
 
 [tool.poetry.extras]

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ omit =
 
 [tox:tox]
 isolated_build = true
-envlist = py310, py311, py312, format, lint, build
+envlist = py310, py311, py312, format, lint, build-linux, build-macos
 
 [gh-actions]
 python =
@@ -98,7 +98,35 @@ commands =
     flake8 toshi_hazard_store tests
     mypy toshi_hazard_store tests
 
-[testenv:build]
+# [testenv:build]
+# allowlist_externals =
+#     poetry
+#     mkdocs
+#     twine
+# extras =
+#     doc
+#     dev
+# commands =
+#     poetry build
+#     mkdocs build
+#     twine check dist/*
+
+[testenv:build-linux]
+platform = linux
+allowlist_externals =
+    poetry
+    mkdocs
+    twine
+extras =
+    doc
+    dev
+commands =
+    poetry build
+    mkdocs build
+    twine check dist/*
+
+[testenv:build-macos]
+platform = darwin
 allowlist_externals =
     poetry
     mkdocs

--- a/tests/model/conftest.py
+++ b/tests/model/conftest.py
@@ -23,7 +23,7 @@ def storage_path(tmpdir_factory):
     return Path(tmpdir_factory.mktemp("hazard_storage"))
 
 
-@pytest.fixture
+@pytest.fixture(scope='session')
 def compatible_hazard_calc_data():
     now = datetime.now(timezone.utc)
     return {"unique_id": "chc1", "created_at": now, "updated_at": now}

--- a/tests/model/test_hazard_models_manager.py
+++ b/tests/model/test_hazard_models_manager.py
@@ -42,7 +42,7 @@ def test_compatible_hazard_calculation_round_trip(storage_path):
 
 def test_compatible_hazard_calculation_update(ch_manager, compatible_hazard_calc_data):
     new_updated_at = datetime.now(timezone.utc)
-    data_to_update = {"updated_at": new_updated_at.isoformat()}
+    data_to_update = {"updated_at": new_updated_at}
     ch_manager.update(compatible_hazard_calc_data["unique_id"], data_to_update)
 
     chc = ch_manager.load(compatible_hazard_calc_data["unique_id"])
@@ -78,7 +78,7 @@ def test_hazard_curve_producer_config_create_load(hcp_manager, hazard_curve_prod
 
 def test_hazard_curve_producer_config_update(hcp_manager, hazard_curve_producer_config_data):
     new_updated_at = datetime.now(timezone.utc)
-    data_to_update = {"updated_at": new_updated_at.isoformat()}
+    data_to_update = {"updated_at": new_updated_at}
     hcp_manager.update("ImageDigest1234567890", data_to_update)
 
     hcp = hcp_manager.load("ImageDigest1234567890")

--- a/tests/oq_import/conftest.py
+++ b/tests/oq_import/conftest.py
@@ -149,10 +149,10 @@ def hdf5_calc_fixture():
 
 
 @pytest.fixture
-def mock_task_args_file_path(tmp_path, latest_config):
+def mock_task_args_file_path(tmp_path, general_task_id, task_id, latest_config):
 
     # mock artefects
-    subtasks_folder = tmp_path / GT_ID / 'subtasks'
+    subtasks_folder = tmp_path / general_task_id / 'subtasks'
     subtasks_folder.mkdir(parents=True)
     # task_id = '12345'
     ta_fixt = json.load(open(latest_config, 'r'))
@@ -170,7 +170,7 @@ def mock_task_args_file_path(tmp_path, latest_config):
         "site_params-locations_file": None,
     }
 
-    task_args_file = subtasks_folder / str(TASK_ID) / TASK_ARGS_JSON
+    task_args_file = subtasks_folder / str(task_id) / TASK_ARGS_JSON
     task_args_file.parent.mkdir()
     task_args_file.write_text(json.dumps(ta))
     # config = oq_config.config_from_task(task_id, subtasks_folder)

--- a/toshi_hazard_store/__init__.py
+++ b/toshi_hazard_store/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """GNS Science"""
 __email__ = 'nshm@gns.cri.nz'
-__version__ = '1.2.3'
+__version__ = '1.2.4'
 
 
 import toshi_hazard_store.model as model

--- a/toshi_hazard_store/model/pyarrow/pyarrow_aggr_dataset.py
+++ b/toshi_hazard_store/model/pyarrow/pyarrow_aggr_dataset.py
@@ -1,24 +1,22 @@
 """pyarrow helper function"""
 
 import logging
-import pathlib
-import uuid
-from functools import partial
 from typing import TYPE_CHECKING, Iterable, Optional
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-import pyarrow.dataset as ds
 from pyarrow import fs
 
+from toshi_hazard_store.model.pyarrow import pyarrow_dataset
 from toshi_hazard_store.model.pyarrow.dataset_schema import get_hazard_aggregate_schema
-from toshi_hazard_store.model.pyarrow.pyarrow_dataset import _write_metadata
 
 log = logging.getLogger(__name__)
 
 if TYPE_CHECKING:  # pragma: no cover
     from toshi_hazard_store.model.hazard_models_pydantic import HazardAggregateCurve
+
+hazard_agreggate_schema = get_hazard_aggregate_schema()
 
 
 def append_models_to_dataset(
@@ -42,35 +40,35 @@ def append_models_to_dataset(
 
     Returns: None
     """
-    item_dicts = [hag.model_dump() for hag in models]
-    df = pd.DataFrame(item_dicts)
+    table = table_from_models(models)
+    pyarrow_dataset.append_models_to_dataset(
+        table,
+        base_dir,
+        dataset_format,
+        filesystem,
+        partitioning,
+        existing_data_behavior,
+        schema=hazard_agreggate_schema,
+    )
+
+
+def table_from_models(models: Iterable['HazardAggregateCurve']) -> pa.Table:
+    """build a pyarrow table from HazardAggregateCurve models.
+
+    Args:
+    models: An iterable of model data objects.
+
+    Returns: The pyarrow hazard aggregations table.
+    """
+
+    df = pd.DataFrame([hazagg.model_dump() for hazagg in models])
 
     # MANUALLY set the dataframe typing to match the pyarrow schema UGHHHH
     dtype = {
         "vs30": "int32",
     }
+    # coerce the the types
     df = df.astype(dtype)
-    # coerce the the types UGGH
     df['values'] = df['values'].apply(lambda x: np.array(x, dtype=np.float32))
 
-    log.debug("in df >>>")
-    log.debug(df.info())
-    log.debug("in df <<<")
-
-    table = pa.Table.from_pandas(df)
-
-    schema = get_hazard_aggregate_schema()
-    using_s3 = isinstance(filesystem, fs.S3FileSystem)
-    write_metadata_fn = partial(_write_metadata, using_s3, pathlib.Path(base_dir))
-    ds.write_dataset(
-        table,
-        base_dir=base_dir,
-        basename_template="%s-part-{i}.%s" % (uuid.uuid4(), dataset_format),
-        partitioning=partitioning,
-        partitioning_flavor="hive",
-        existing_data_behavior=existing_data_behavior,
-        format=dataset_format,
-        file_visitor=write_metadata_fn,
-        filesystem=filesystem,
-        schema=schema,
-    )
+    return pa.Table.from_pandas(df)

--- a/toshi_hazard_store/model/pyarrow/pyarrow_dataset.py
+++ b/toshi_hazard_store/model/pyarrow/pyarrow_dataset.py
@@ -94,7 +94,8 @@ def append_models_to_dataset(
     dataset_format: str = 'parquet',
     filesystem: Optional[fs.FileSystem] = None,
     partitioning: Optional[Iterable[str]] = None,
-    existing_data_behavior: str = "overwrite_or_ignore",
+    existing_data_behavior: Optional[str] = "overwrite_or_ignore",
+    schema: Optional[pa.schema] = None,
 ) -> None:
     """
     Appends realisations to a dataset using the pyarrow library.
@@ -105,7 +106,8 @@ def append_models_to_dataset(
     dataset_format (optional): The format of the dataset. Defaults to 'parquet'.
     filesystem (optional): The file system to use for storage. Defaults to None.
     partitioning (optional): The partitioning scheme to apply. Defaults to ['nloc_0'].
-    existing_data_behavior: how to treat existing data (see pyarrow docs).
+    existing_data_behavior (optional): how to treat existing data (see pyarrow docs).
+    schema (optional): the dataset schema.
 
     Returns: None
 
@@ -129,6 +131,7 @@ def append_models_to_dataset(
         format=dataset_format,
         file_visitor=write_metadata_fn,
         filesystem=filesystem,
+        schema=schema,
     )
 
 

--- a/toshi_hazard_store/oq_import/oq_config.py
+++ b/toshi_hazard_store/oq_import/oq_config.py
@@ -110,7 +110,10 @@ def process_hdf5(
             hdf5_file_name = calc_files[0]
             log.info(f"extracting {hdf5_file_name} from {hdf5_archive} into {subtask_folder}")
             myzip.extract(hdf5_file_name, subtask_folder)
-            hdf5_archive.unlink()  # delete the zip
+
+        # delete the archive
+        hdf5_archive.unlink()
+
     else:  # pragma: no cover
         log.info('skipping hdf5 download - files exist.')
 


### PR DESCRIPTION
closing #128 

 - fix unlink()  bug only apparent on windows.
 - fix warnings from wrong datetime type.
 - make fixture session scoped to avoid datetime bug.
 - add aggregate dataset coverage to `pyarrow_dataset.append_models_to_dataset` method.

nothing so far reproduces the TZDATA bug found in THP.