### PR TITLE
Feature/137 disagg agg

### DIFF
--- a/tests/model/pyarrow/test_pyarrow_disagg_aggr_dataset.py
+++ b/tests/model/pyarrow/test_pyarrow_disagg_aggr_dataset.py
@@ -1,6 +1,7 @@
 import pyarrow.dataset as ds
 import pytest
 
+from toshi_hazard_store.model.constraints import ProbabilityEnum
 from toshi_hazard_store.model.hazard_models_pydantic import DisaggregationAggregate
 from toshi_hazard_store.model.pyarrow import (
     pyarrow_dataset,
@@ -29,7 +30,7 @@ def disagg_aggregate_models():
                 imt="PGA",
                 vs30=400,
                 target_aggr="mean",
-                probability="_10_PCT_IN_50YRS",
+                probability=ProbabilityEnum._10_PCT_IN_50YRS,
                 imtl=0.1,
                 aggr="mean",
                 bins_digest="abc123def456",

--- a/tests/model/pyarrow/test_pyarrow_disagg_aggr_dataset.py
+++ b/tests/model/pyarrow/test_pyarrow_disagg_aggr_dataset.py
@@ -1,0 +1,59 @@
+import pyarrow.dataset as ds
+import pytest
+
+from toshi_hazard_store.model.hazard_models_pydantic import DisaggregationAggregate
+from toshi_hazard_store.model.pyarrow import (
+    pyarrow_dataset,
+    pyarrow_disagg_aggr_dataset,
+)
+from toshi_hazard_store.model.pyarrow.disagg_reshape import reshape_disagg_values
+
+_BINS = {
+    "mag": ["5.5", "6.5", "7.5"],
+    "dist": ["10.0", "50.0", "100.0", "200.0"],
+    "eps": ["-1.0", "0.0", "1.0"],
+}
+_EXPECTED_SHAPE = (3, 4, 3)
+_N_VALUES = 3 * 4 * 3
+
+
+@pytest.fixture
+def disagg_aggregate_models():
+    def _models(n=10):
+        for i in range(n):
+            yield DisaggregationAggregate(
+                compatible_calc_id="NZSHM22",
+                hazard_model_id="NSHM_v1.0.4",
+                nloc_001="-38.330~175.550",
+                nloc_0="-38.0~175.0",
+                imt="PGA",
+                vs30=400,
+                target_aggr="mean",
+                probability="_10_PCT_IN_50YRS",
+                imtl=0.1,
+                aggr="mean",
+                bins_digest="abc123def456",
+                disagg_bins=_BINS,
+                disagg_values=[float(j) for j in range(_N_VALUES)],
+            )
+
+    yield _models()
+
+
+def test_serialise_disagg_aggregate(tmp_path, disagg_aggregate_models):
+    output_folder = tmp_path / "ds_disagg_aggr"
+
+    partitioning = ['vs30', 'nloc_0']
+    base_dir, filesystem = pyarrow_dataset.configure_output(str(output_folder))
+    pyarrow_disagg_aggr_dataset.append_models_to_dataset(
+        models=disagg_aggregate_models, base_dir=base_dir, filesystem=filesystem, partitioning=partitioning
+    )
+
+    schema = DisaggregationAggregate.pyarrow_schema()
+    dataset = ds.dataset(output_folder, format='parquet', partitioning='hive', schema=schema)
+    table = dataset.to_table()
+    rows = table.to_pylist()
+
+    assert len(rows) == 10
+    arr = reshape_disagg_values(rows[0]["disagg_values"], rows[0]["disagg_bins"])
+    assert arr.shape == _EXPECTED_SHAPE

--- a/tests/model/pyarrow/test_pyarrow_disagg_aggr_dataset.py
+++ b/tests/model/pyarrow/test_pyarrow_disagg_aggr_dataset.py
@@ -1,3 +1,5 @@
+import math
+
 import pyarrow.dataset as ds
 import pytest
 
@@ -14,8 +16,8 @@ _BINS = {
     "dist": ["10.0", "50.0", "100.0", "200.0"],
     "eps": ["-1.0", "0.0", "1.0"],
 }
-_EXPECTED_SHAPE = (3, 4, 3)
-_N_VALUES = 3 * 4 * 3
+_EXPECTED_SHAPE = tuple([len(element) for element in _BINS.values()])
+_N_VALUES = math.prod(_EXPECTED_SHAPE)
 
 
 @pytest.fixture
@@ -38,7 +40,7 @@ def disagg_aggregate_models():
                 disagg_values=[float(j) for j in range(_N_VALUES)],
             )
 
-    yield _models()
+    return _models()
 
 
 def test_serialise_disagg_aggregate(tmp_path, disagg_aggregate_models):

--- a/tests/model/test_hazard_models_pydantic.py
+++ b/tests/model/test_hazard_models_pydantic.py
@@ -1,9 +1,11 @@
+import enum
 import typing
 from datetime import datetime, timezone
 
 import pyarrow as pa
 import pytest
 
+from toshi_hazard_store.model.constraints import ProbabilityEnum
 from toshi_hazard_store.model.hazard_models_pydantic import (
     AwsEcrImage,
     CompatibleHazardCalculation,
@@ -115,7 +117,7 @@ class TestDisaggregationAggregate:
             imt="PGA",
             vs30=400,
             target_aggr="mean",
-            probability="_10_PCT_IN_50YRS",
+            probability=ProbabilityEnum._10_PCT_IN_50YRS,
             imtl=0.1,
             aggr="mean",
             bins_digest="abc123def456",
@@ -125,12 +127,19 @@ class TestDisaggregationAggregate:
 
     def test_model_dump(self):
         model = DisaggregationAggregate(**self.data)
-        assert model.model_dump() == self.data
+        expected = {**self.data, "probability": self.data["probability"].name}
+        assert model.model_dump() == expected
 
     def test_missing_required_field(self):
         invalid = dict(**self.data)
         del invalid["bins_digest"]
         with pytest.raises(ValueError, match=r"Field required"):
+            DisaggregationAggregate(**invalid)
+
+    def test_invalid_probability_raises(self):
+        invalid = dict(**self.data)
+        invalid["probability"] = 999.9
+        with pytest.raises(ValueError):
             DisaggregationAggregate(**invalid)
 
     def test_empty_bins_raises(self):
@@ -157,6 +166,8 @@ class TestDisaggregationAggregate:
             args = typing.get_args(py_anno)
 
             if py_anno is str:
+                return pa.types.is_string(a) or pa.types.is_large_string(a)
+            if isinstance(py_anno, type) and issubclass(py_anno, enum.Enum):
                 return pa.types.is_string(a) or pa.types.is_large_string(a)
             if py_anno is int:
                 return pa.types.is_integer(a)

--- a/tests/model/test_hazard_models_pydantic.py
+++ b/tests/model/test_hazard_models_pydantic.py
@@ -177,9 +177,7 @@ class TestDisaggregationAggregate:
                 return pa.types.is_list(a) and _is_compatible(args[0], a.value_type)
             if origin is dict:
                 return (
-                    pa.types.is_map(a)
-                    and _is_compatible(args[0], a.key_type)
-                    and _is_compatible(args[1], a.item_type)
+                    pa.types.is_map(a) and _is_compatible(args[0], a.key_type) and _is_compatible(args[1], a.item_type)
                 )
             raise TypeError(f"Unrecognised pydantic annotation: {py_anno!r}")
 

--- a/tests/model/test_hazard_models_pydantic.py
+++ b/tests/model/test_hazard_models_pydantic.py
@@ -1,5 +1,7 @@
+import typing
 from datetime import datetime, timezone
 
+import pyarrow as pa
 import pytest
 
 from toshi_hazard_store.model.hazard_models_pydantic import (
@@ -142,3 +144,43 @@ class TestDisaggregationAggregate:
         invalid["disagg_values"] = invalid["disagg_values"][:-1]
         with pytest.raises(ValueError, match=r"disagg_values length"):
             DisaggregationAggregate(**invalid)
+
+    def test_schema_matches_pydantic_fields(self):
+        """Assert that get_disagg_aggregate_schema stays in sync with DisaggregationAggregate."""
+
+        def _strip_dict(t: pa.DataType) -> pa.DataType:
+            return t.value_type if pa.types.is_dictionary(t) else t
+
+        def _is_compatible(py_anno, arrow_type: pa.DataType) -> bool:
+            a = _strip_dict(arrow_type)
+            origin = typing.get_origin(py_anno)
+            args = typing.get_args(py_anno)
+
+            if py_anno is str:
+                return pa.types.is_string(a) or pa.types.is_large_string(a)
+            if py_anno is int:
+                return pa.types.is_integer(a)
+            if py_anno is float:
+                return pa.types.is_floating(a)
+            if origin is list:
+                return pa.types.is_list(a) and _is_compatible(args[0], a.value_type)
+            if origin is dict:
+                return (
+                    pa.types.is_map(a)
+                    and _is_compatible(args[0], a.key_type)
+                    and _is_compatible(args[1], a.item_type)
+                )
+            raise TypeError(f"Unrecognised pydantic annotation: {py_anno!r}")
+
+        schema = DisaggregationAggregate.pyarrow_schema()
+        pydantic_fields = DisaggregationAggregate.model_fields
+
+        assert list(pydantic_fields.keys()) == schema.names, (
+            f"Field order mismatch:\n  pydantic: {list(pydantic_fields.keys())}\n  schema:   {schema.names}"
+        )
+
+        for name, field_info in pydantic_fields.items():
+            arrow_field = schema.field(name)
+            assert _is_compatible(field_info.annotation, arrow_field.type), (
+                f"field '{name}': pydantic {field_info.annotation!r} incompatible with arrow type {arrow_field.type}"
+            )

--- a/tests/model/test_hazard_models_pydantic.py
+++ b/tests/model/test_hazard_models_pydantic.py
@@ -5,6 +5,7 @@ import pytest
 from toshi_hazard_store.model.hazard_models_pydantic import (
     AwsEcrImage,
     CompatibleHazardCalculation,
+    DisaggregationAggregate,
     HazardAggregateCurve,
     HazardCurveProducerConfig,
 )
@@ -95,3 +96,49 @@ class TestHazardAggregateCurve:
         with pytest.raises(ValueError, match=r"expected 44 values but") as exc:
             HazardAggregateCurve(**invalid_data)
         print(exc)
+
+
+class TestDisaggregationAggregate:
+    def setup_method(self):
+        self.bins = {
+            "mag": ["5.5", "6.5", "7.5"],
+            "dist": ["10.0", "50.0", "100.0", "200.0"],
+            "eps": ["-1.0", "0.0", "1.0"],
+        }
+        self.data = dict(
+            compatible_calc_id="NZSHM22",
+            hazard_model_id="NSHM_v1.0.4",
+            nloc_001="-38.330~175.550",
+            nloc_0="-38.0~175.0",
+            imt="PGA",
+            vs30=400,
+            target_aggr="mean",
+            probability="_10_PCT_IN_50YRS",
+            imtl=0.1,
+            aggr="mean",
+            bins_digest="abc123def456",
+            disagg_bins=self.bins,
+            disagg_values=[float(i) for i in range(3 * 4 * 3)],
+        )
+
+    def test_model_dump(self):
+        model = DisaggregationAggregate(**self.data)
+        assert model.model_dump() == self.data
+
+    def test_missing_required_field(self):
+        invalid = dict(**self.data)
+        del invalid["bins_digest"]
+        with pytest.raises(ValueError, match=r"Field required"):
+            DisaggregationAggregate(**invalid)
+
+    def test_empty_bins_raises(self):
+        invalid = dict(**self.data)
+        invalid["disagg_bins"] = {}
+        with pytest.raises(ValueError, match=r"disagg_bins must not be empty"):
+            DisaggregationAggregate(**invalid)
+
+    def test_values_shape_mismatch_raises(self):
+        invalid = dict(**self.data)
+        invalid["disagg_values"] = invalid["disagg_values"][:-1]
+        with pytest.raises(ValueError, match=r"disagg_values length"):
+            DisaggregationAggregate(**invalid)

--- a/toshi_hazard_store/model/hazard_models_pydantic.py
+++ b/toshi_hazard_store/model/hazard_models_pydantic.py
@@ -1,11 +1,12 @@
 """The hazard metatdata models for (de)serialisation as json."""
 
 from datetime import datetime, timezone
+from math import prod
 from typing import List
 
 import pyarrow as pa
 from lancedb.pydantic import pydantic_to_schema
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from toshi_hazard_store.oq_import.aws_ecr_docker_image import AwsEcrImage
 
@@ -121,3 +122,61 @@ class HazardAggregateCurve(BaseModel):
             )
 
         return arrow_schema
+
+
+class DisaggregationAggregate(BaseModel):
+    """Aggregated disaggregation arrays across realisations.
+
+    Attributes:
+        compatible_calc_id: FK for hazard-calc equivalence.
+        hazard_model_id: NSHM hazard model identifier e.g. "NSHM_v1.0.4" (caller-supplied).
+        nloc_001: location string at 0.001° resolution e.g. "-38.330~175.550".
+        nloc_0: location string at 1.0° resolution (used for partitioning).
+        imt: intensity measure type label e.g. "PGA", "SA(1.0)".
+        vs30: VS30 value in m/s.
+        target_aggr: hazard-curve aggregation the disagg was conditioned on e.g. "mean", "0.5".
+        probability: ProbabilityEnum name supplied by caller e.g. "_10_PCT_IN_50YRS".
+        imtl: IML at which the disagg was computed.
+        aggr: aggregation type applied across realisations e.g. "mean", "0.1".
+        bins_digest: sha256[:16] over sorted axes + sorted bin centres (compatibility key).
+        disagg_bins: ordered map ``{axis_name: [bin_centre_str, ...]}`` — key order
+            defines the axis order of ``disagg_values``; values are stringified bin centres.
+        disagg_values: flattened disaggregation array over ``disagg_bins`` axes, C-order.
+    """
+
+    compatible_calc_id: str
+    hazard_model_id: str
+    nloc_001: str
+    nloc_0: str
+    imt: str
+    vs30: int
+    target_aggr: str
+    probability: str
+    imtl: float
+    aggr: str
+    bins_digest: str
+    disagg_bins: dict[str, list[str]]
+    disagg_values: List[float]
+
+    @field_validator("disagg_bins")
+    @classmethod
+    def validate_bins_nonempty(cls, value: dict) -> dict:
+        if not value:
+            raise ValueError("disagg_bins must not be empty")
+        return value
+
+    @model_validator(mode="after")
+    def validate_values_shape(self) -> "DisaggregationAggregate":
+        expected = prod(len(v) for v in self.disagg_bins.values())
+        if len(self.disagg_values) != expected:
+            raise ValueError(
+                f"disagg_values length {len(self.disagg_values)} does not match product of bin sizes {expected}"
+            )
+        return self
+
+    @staticmethod
+    def pyarrow_schema() -> pa.schema:
+        """A pyarrow schema for aggregate disaggregation datasets."""
+        from toshi_hazard_store.model.pyarrow.dataset_schema import get_disagg_aggregate_schema
+
+        return get_disagg_aggregate_schema()

--- a/toshi_hazard_store/model/hazard_models_pydantic.py
+++ b/toshi_hazard_store/model/hazard_models_pydantic.py
@@ -130,15 +130,15 @@ class DisaggregationAggregate(BaseModel):
     Attributes:
         compatible_calc_id: FK for hazard-calc equivalence.
         hazard_model_id: NSHM hazard model identifier e.g. "NSHM_v1.0.4" (caller-supplied).
+        bins_digest: sha256[:16] over sorted axes + sorted bin centres (compatibility key).
         nloc_001: location string at 0.001° resolution e.g. "-38.330~175.550".
         nloc_0: location string at 1.0° resolution (used for partitioning).
-        imt: intensity measure type label e.g. "PGA", "SA(1.0)".
         vs30: VS30 value in m/s.
+        imt: intensity measure type label e.g. "PGA", "SA(1.0)".
         target_aggr: hazard-curve aggregation the disagg was conditioned on e.g. "mean", "0.5".
         probability: ProbabilityEnum name supplied by caller e.g. "_10_PCT_IN_50YRS".
         imtl: IML at which the disagg was computed.
         aggr: aggregation type applied across realisations e.g. "mean", "0.1".
-        bins_digest: sha256[:16] over sorted axes + sorted bin centres (compatibility key).
         disagg_bins: ordered map ``{axis_name: [bin_centre_str, ...]}`` — key order
             defines the axis order of ``disagg_values``; values are stringified bin centres.
         disagg_values: flattened disaggregation array over ``disagg_bins`` axes, C-order.
@@ -146,15 +146,15 @@ class DisaggregationAggregate(BaseModel):
 
     compatible_calc_id: str
     hazard_model_id: str
+    bins_digest: str
     nloc_001: str
     nloc_0: str
-    imt: str
     vs30: int
+    imt: str
     target_aggr: str
     probability: str
     imtl: float
     aggr: str
-    bins_digest: str
     disagg_bins: dict[str, list[str]]
     disagg_values: List[float]
 

--- a/toshi_hazard_store/model/hazard_models_pydantic.py
+++ b/toshi_hazard_store/model/hazard_models_pydantic.py
@@ -9,6 +9,7 @@ from lancedb.pydantic import pydantic_to_schema
 from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
 
 from toshi_hazard_store.model.constraints import ProbabilityEnum
+from toshi_hazard_store.model.pyarrow.dataset_schema import get_disagg_aggregate_schema
 from toshi_hazard_store.oq_import.aws_ecr_docker_image import AwsEcrImage
 
 USE_64BIT_VALUES = False
@@ -182,6 +183,4 @@ class DisaggregationAggregate(BaseModel):
     @staticmethod
     def pyarrow_schema() -> pa.schema:
         """A pyarrow schema for aggregate disaggregation datasets."""
-        from toshi_hazard_store.model.pyarrow.dataset_schema import get_disagg_aggregate_schema
-
         return get_disagg_aggregate_schema()

--- a/toshi_hazard_store/model/hazard_models_pydantic.py
+++ b/toshi_hazard_store/model/hazard_models_pydantic.py
@@ -6,8 +6,9 @@ from typing import List
 
 import pyarrow as pa
 from lancedb.pydantic import pydantic_to_schema
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
 
+from toshi_hazard_store.model.constraints import ProbabilityEnum
 from toshi_hazard_store.oq_import.aws_ecr_docker_image import AwsEcrImage
 
 USE_64BIT_VALUES = False
@@ -152,11 +153,15 @@ class DisaggregationAggregate(BaseModel):
     vs30: int
     imt: str
     target_aggr: str
-    probability: str
+    probability: ProbabilityEnum
     imtl: float
     aggr: str
     disagg_bins: dict[str, list[str]]
     disagg_values: List[float]
+
+    @field_serializer("probability")
+    def serialize_probability(self, value: ProbabilityEnum) -> str:
+        return value.name
 
     @field_validator("disagg_bins")
     @classmethod

--- a/toshi_hazard_store/model/pyarrow/dataset_schema.py
+++ b/toshi_hazard_store/model/pyarrow/dataset_schema.py
@@ -66,6 +66,56 @@ def get_disagg_realisation_schema(use_64bit_values: bool = USE_64BIT_VALUES_DEFA
     )
 
 
+def get_disagg_aggregate_schema(use_64bit_values: bool = USE_64BIT_VALUES_DEFAULT) -> pa.schema:
+    """A schema for disaggregation aggregate datasets.
+
+    One row per (compatible_calc_id, hazard_model_id, location, imt, vs30, target_aggr,
+    probability, imtl, aggr). The disaggregation grid is stored as a single flattened list
+    (``disagg_values``) in C-order; axis order and bin centres are in ``disagg_bins``.
+
+    Attributes:
+        compatible_calc_id: FK for hazard-calc equivalence
+        hazard_model_id: NSHM hazard model identifier e.g. "NSHM_v1.0.4" (caller-supplied)
+        bins_digest: sha256 of the bin centers/labels — compatibility key for combining disaggs
+        nloc_001: location string at 0.001° resolution e.g. "-38.330~175.550"
+        nloc_0: location string at 1.0° resolution (used for partitioning)
+        vs30: VS30 value in m/s
+        imt: intensity measure type label e.g. "PGA", "SA(1.0)"
+        target_aggr: hazard-curve aggregation the disagg was conditioned on e.g. "mean", "0.5"
+        probability: ProbabilityEnum name supplied by caller e.g. "_10_PCT_IN_50YRS"
+        imtl: IML at which the disagg was computed
+        aggr: aggregation type applied across realisations e.g. "mean", "0.1"
+        disagg_bins: ordered map ``{axis_name: [bin_centre_str, ...]}`` — key order
+            defines the axis order of ``disagg_values``; values are stringified bin centres
+        disagg_values: flattened disaggregation array over ``disagg_bins`` axes, C-order
+    """
+    vtype = pa.float64() if use_64bit_values else pa.float32()
+    imtl_type = pa.float64() if use_64bit_values else pa.float32()
+    values_type = pa.list_(vtype)
+    vs30_type = pa.int32()
+    dict_type = pa.dictionary(pa.int8(), pa.string(), False)
+    str_type = pa.string()
+    bins_map_type = pa.map_(pa.string(), pa.list_(pa.string()))
+
+    return pa.schema(
+        [
+            ("compatible_calc_id", str_type),
+            ("hazard_model_id", dict_type),
+            ("bins_digest", dict_type),
+            ("nloc_001", str_type),
+            ("nloc_0", str_type),
+            ("vs30", vs30_type),
+            ("imt", dict_type),
+            ("target_aggr", dict_type),
+            ("probability", dict_type),
+            ("imtl", imtl_type),
+            ("aggr", dict_type),
+            ("disagg_bins", bins_map_type),
+            ("disagg_values", values_type),
+        ]
+    )
+
+
 def get_hazard_realisation_schema(use_64_bit_values: bool = USE_64BIT_VALUES_DEFAULT) -> pa.schema:
     """A schema for Hazard Realization curves dataset extracted from openquake.
 

--- a/toshi_hazard_store/model/pyarrow/pyarrow_disagg_aggr_dataset.py
+++ b/toshi_hazard_store/model/pyarrow/pyarrow_disagg_aggr_dataset.py
@@ -1,0 +1,44 @@
+"""pyarrow helper function for disaggregation aggregate datasets."""
+
+import logging
+from typing import Iterable, Optional
+
+from pyarrow import fs
+
+from toshi_hazard_store.model.hazard_models_pydantic import DisaggregationAggregate
+from toshi_hazard_store.model.pyarrow import pyarrow_dataset
+
+log = logging.getLogger(__name__)
+
+
+def append_models_to_dataset(
+    models: Iterable['DisaggregationAggregate'],
+    base_dir: str,
+    dataset_format: str = 'parquet',
+    filesystem: Optional[fs.FileSystem] = None,
+    partitioning: Optional[Iterable[str]] = None,
+    existing_data_behavior: str = "overwrite_or_ignore",
+) -> None:
+    """
+    Write DisaggregationAggregate models to dataset.
+
+    Args:
+    models: An iterable of model data objects.
+    base_dir: The path where the data will be stored.
+    dataset_format (optional): The format of the dataset. Defaults to 'parquet'.
+    filesystem (optional): The file system to use for storage. Defaults to None.
+    partitioning (optional): The partitioning scheme to apply. Defaults to ['nloc_0'].
+    existing_data_behavior: how to treat existing data (see pyarrow docs).
+
+    Returns: None
+    """
+    table = pyarrow_dataset.table_from_models(models)
+    pyarrow_dataset.append_models_to_dataset(
+        table,
+        base_dir,
+        dataset_format,
+        filesystem,
+        partitioning,
+        existing_data_behavior,
+        schema=DisaggregationAggregate.pyarrow_schema(),
+    )


### PR DESCRIPTION
closes #137 and #31

Aggregation types ("mean", "0.9") are not stored as or validated as `AggregationEnum` which follows the pattern established by  hazard curve aggregates.