### PR TITLE
Feature/160 disagg agg query

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.5.0
+current_version = 2.0.0
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(-(?P<release>.*)-(?P<build>\d+))?

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@
 
 ### Added
 - Import disaggregation realizations from OpenQuake
+- Store disaggregation aggregates as PyArrow parquet datasets (`DisaggregationAggregate` model, schema, writer)
+- Query disaggregation aggregates via `toshi_hazard_store.query.get_disagg_aggregates()` with naive/d1/d2 strategies
+- `DisaggregationAggregate.to_ndarray()` to reshape flat `disagg_values` into an N-D array
+- `_bins_digest_from_dict()` shared helper for computing the bins compatibility digest from a `disagg_bins` dict
+- Documentation for disaggregation aggregates: updated `docs/domain_model/disaggregation_models.md` and query Quick Start
 
 ### Changed
 - Unpin `lancedb` dependency
+- `dataset_cache.py` refactored: shared `_open_partitioned_dataset()` helper used by all six dataset accessors (hazard + disagg)
 
 ## [1.5.0] 2026-04-13
 

--- a/docs/api/query/index.md
+++ b/docs/api/query/index.md
@@ -6,6 +6,7 @@ The `toshi_hazard_store.query` package provides the main public interface for qu
 
 ```python
 from toshi_hazard_store import query
+from toshi_hazard_store.model.constraints import ProbabilityEnum
 
 # Query hazard curves
 curves = query.get_hazard_curves(
@@ -19,6 +20,28 @@ curves = query.get_hazard_curves(
 
 for curve in curves:
     print(f"{curve.imt} at {curve.nloc_001}: {curve.values}")
+
+# Query disaggregation aggregates
+disaggs = query.get_disagg_aggregates(
+    location_codes=["-41.300~174.800"],
+    vs30s=[400],
+    hazard_model="NSHM_v1.0.4",
+    imts=["PGA"],
+    aggs=["mean"],
+    target_aggrs=["mean"],
+    probabilities=[ProbabilityEnum._10_PCT_IN_50YRS],
+    disagg_bins={
+        "mag": ["5.5", "6.5", "7.5"],
+        "dist": ["10.0", "50.0", "100.0", "200.0"],
+        "eps": ["-1.0", "0.0", "1.0"],
+    },
+    strategy="d2"  # or "d1", "naive"
+)
+
+for disagg in disaggs:
+    print(f"{disagg.imt} at {disagg.nloc_001}, prob={disagg.probability.name}")
+    arr = disagg.to_ndarray()  # reshape to N-D array over disagg_bins axes
+    print(f"  shape: {arr.shape}")
 
 # Query gridded hazard
 gridded = query.get_gridded_hazard(

--- a/docs/domain_model/disaggregation_models.md
+++ b/docs/domain_model/disaggregation_models.md
@@ -32,7 +32,7 @@ The schema includes:
 - `imt` (string) - Intensity measure type (e.g., "PGA", "SA(1.0)")
 - `target_aggr` (string) - Hazard-curve aggregation the disagg was conditioned on (e.g., "mean")
 - `probability` (string) - Return-period probability as a `ProbabilityEnum` name (e.g., "_10_PCT_IN_50YRS")
-- `imtl` (float) - IML at which the disagg was computed
+- `imtl` (float) - Intensity measure level at which the disagg was computed
 - `aggr` (string) - Aggregation type across realisations (e.g., "mean", "0.1")
 - `disagg_bins` (map of string → list of string) - Ordered map of axis name to bin-centre strings; key order defines the axis order of `disagg_values`
 - `disagg_values` (list of float32) - Flattened C-order disaggregation array over `disagg_bins` axes

--- a/docs/domain_model/disaggregation_models.md
+++ b/docs/domain_model/disaggregation_models.md
@@ -1,69 +1,95 @@
-!!! warning "Experimental / Not Implemented"
-    The disaggregation models described on this page are **not currently implemented** in the codebase.
-    
-    There is experimental code in `toshi_hazard_store/model/revision_4/extract_disagg_hdf5.py` for extracting disaggregation data from OpenQuake HDF5 files, but the pydantic models described below do not exist yet.
-    
-    This page is kept for reference and future implementation planning.
+# Disaggregation
 
-**Tables:**
+These models represent aggregated disaggregation arrays derived from OpenQuake PSHA engine outputs.
 
- - **DisaggAggregationExceedance** - Disaggregation curves of Probablity of Exceedance
- - **DisaggAggregationOccurence** - Disaggregation curves of Probablity of Occurence
+## Disaggregation Aggregate
 
-The base class **LocationIndexedModel** provides common attributes and indexing for models that support location-based indexing.
+The core model for aggregated disaggregation data, stored as PyArrow parquet datasets.
 
-The base class **DisaggAggregationBase** defines attribtues common to both types of disaggregation curve.
+::: toshi_hazard_store.model.hazard_models_pydantic.DisaggregationAggregate
+    options:
+      show_source: true
+      members: false
+      attributes: true
 
-```mermaid
-classDiagram
-direction TB
+## PyArrow Schema
 
-class LocationIndexedModel {
+The `DisaggregationAggregate` model can be converted to a PyArrow schema for dataset I/O:
 
-    partition_key = UnicodeAttribute(hash_key=True)  # For this we will use a downsampled location to 1.0 degree
-    sort_key = UnicodeAttribute(range_key=True)
-
-    nloc_001 = UnicodeAttribute()  # 0.001deg ~100m grid
-    nloc_01 = UnicodeAttribute()  # 0.01deg ~1km grid
-    nloc_1 = UnicodeAttribute()  # 0.1deg ~10km grid
-    nloc_0 = UnicodeAttribute()  # 1.0deg ~100km grid
-
-    version = VersionAttribute()
-    uniq_id = UnicodeAttribute()
-
-    lat = FloatAttribute()  # latitude decimal degrees
-    lon = FloatAttribute()  # longitude decimal degrees
-    
-    vs30 = EnumConstrainedIntegerAttribute(VS30Enum)
-    site_vs30 = FloatAttribute(null=True)
-
-    created = TimestampAttribute(default=datetime_now)
-
-}
-
-class DisaggAggregationBase{
-    ... fields from LocationIndexedModel
-    hazard_model_id = UnicodeAttribute()
-    imt = EnumConstrainedUnicodeAttribute(IntensityMeasureTypeEnum)
-
-    hazard_agg = EnumConstrainedUnicodeAttribute(AggregationEnum)  # eg MEAN
-    disagg_agg = EnumConstrainedUnicodeAttribute(AggregationEnum)
-
-    disaggs = CompressedPickleAttribute()  # a very compressible numpy array,
-    bins = PickleAttribute()  # a much smaller numpy array
-
-    shaking_level = FloatAttribute()
-    probability = EnumAttribute(ProbabilityEnum)  # eg TEN_PCT_IN_50YRS
-}
-
-class DisaggAggregationExceedance{
-    ... fields from DisaggAggregationBase
-}
-
-class DisaggAggregationOccurence{
-    ... fields from DisaggAggregationBase
-}
-LocationIndexedModel <|-- DisaggAggregationBase
-DisaggAggregationBase <| -- DisaggAggregationExceedance
-DisaggAggregationBase <| -- DisaggAggregationOccurence
+```python
+from toshi_hazard_store.model.hazard_models_pydantic import DisaggregationAggregate
+schema = DisaggregationAggregate.pyarrow_schema()
 ```
+
+The schema includes:
+
+- `compatible_calc_id` (string) - Compatible calculation identifier
+- `hazard_model_id` (string) - Model identifier (e.g., "NSHM_v1.0.4")
+- `bins_digest` (string) - sha256[:16] compatibility key over sorted axes + bin centres
+- `nloc_001` (string) - Location to 3 decimal places (e.g., "-41.300~174.800")
+- `nloc_0` (string) - Location to 0 decimal places (e.g., "-41.0~174.0") for partitioning
+- `vs30` (int32) - VS30 value
+- `imt` (string) - Intensity measure type (e.g., "PGA", "SA(1.0)")
+- `target_aggr` (string) - Hazard-curve aggregation the disagg was conditioned on (e.g., "mean")
+- `probability` (string) - Return-period probability as a `ProbabilityEnum` name (e.g., "_10_PCT_IN_50YRS")
+- `imtl` (float) - IML at which the disagg was computed
+- `aggr` (string) - Aggregation type across realisations (e.g., "mean", "0.1")
+- `disagg_bins` (map of string → list of string) - Ordered map of axis name to bin-centre strings; key order defines the axis order of `disagg_values`
+- `disagg_values` (list of float32) - Flattened C-order disaggregation array over `disagg_bins` axes
+
+
+## Dataset Partitioning
+
+Disaggregation aggregate datasets use Hive-style partitioning on `bins_digest / vs30 / nloc_0`:
+
+```
+<dataset_root>/
+├── bins_digest=6028db096c3a9e62/
+│   ├── vs30=400/
+│   │   └── nloc_0=-41.0~174.0/
+│   │       └── <uuid>-part-0.parquet
+│   └── vs30=1500/
+│       └── nloc_0=-41.0~174.0/
+│           └── <uuid>-part-0.parquet
+```
+
+The `bins_digest` partition groups rows with identical bin topology, enabling efficient filtering when querying a specific disaggregation configuration. Use the `d2` query strategy for large datasets to exploit all three partition levels. The `bins_digest` can be obtained from the `disagg_bins` with `toshi_hazard_store.model.revision_4.extract_disagg_hdf5.compute_bins_digest`.
+
+Note that this partitioning is not enforced by `append_models_to_dataset`, it is left to the user to dictate the partitioning either at write time or (more usually) after running [`ths_ds_defrag`](../cli/ths_ds_defrag.md).
+
+## Reshaping disagg_values
+
+`disagg_values` is stored as a flat list. Use `to_ndarray()` to reshape it into an N-D array with axes ordered by `disagg_bins`:
+
+```python
+from toshi_hazard_store import query
+from toshi_hazard_store.model.constraints import ProbabilityEnum
+
+bins = {
+    "mag": ["5.5", "6.5", "7.5"],
+    "dist": ["10.0", "50.0", "100.0", "200.0"],
+    "eps": ["-1.0", "0.0", "1.0"],
+}
+
+for disagg in query.get_disagg_aggregates(
+    location_codes=["-41.300~174.800"],
+    vs30s=[400],
+    hazard_model="NSHM_v1.0.4",
+    imts=["PGA"],
+    aggs=["mean"],
+    target_aggrs=["mean"],
+    probabilities=[ProbabilityEnum._10_PCT_IN_50YRS],
+    disagg_bins=bins,
+    strategy="d2",
+):
+    arr = disagg.to_ndarray()   # shape: (3, 4, 3) for mag × dist × eps
+    print(arr.shape)
+```
+
+The flat storage form is preserved as the canonical representation; reshaping is opt-in and allocates a numpy array on demand.
+
+## Constraint Enums
+
+### Probability Enum
+
+::: toshi_hazard_store.model.constraints.ProbabilityEnum

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,7 @@ nav:
       - Hazard Metadata: domain_model/hazard_metadata.md
       - Hazard Curves: domain_model/openquake_models.md
       - Gridded Hazard: domain_model/gridded_hazard_models.md
-      - Disaggregation (WIP): domain_model/disaggregation_models.md      
+      - Disaggregation: domain_model/disaggregation_models.md
   - CLI tools: 
       - cli/index.md
       - Aggregation CLI workflow: cli/aggregation_cli_workflow.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "toshi-hazard-store"
-version = "1.5.0"
+version = "2.0.0"
 
 homepage = "https://github.com/GNS-Science/toshi-hazard-store"
 description = "Library for saving and retrieving NZHSM openquake hazard results with convenience (uses pyarrow with parquet format)."

--- a/tests/query/test_disagg_aggregate_query.py
+++ b/tests/query/test_disagg_aggregate_query.py
@@ -1,0 +1,355 @@
+"""Tests for get_disagg_aggregates query function and strategies."""
+
+import math
+from unittest import mock
+
+import pytest
+
+from toshi_hazard_store import query
+from toshi_hazard_store.model.constraints import ProbabilityEnum
+from toshi_hazard_store.model.hazard_models_pydantic import DisaggregationAggregate
+from toshi_hazard_store.model.pyarrow import pyarrow_dataset, pyarrow_disagg_aggr_dataset
+from toshi_hazard_store.model.revision_4.extract_disagg_hdf5 import _bins_digest_from_dict
+from toshi_hazard_store.query import datasets as datasets_mod
+from toshi_hazard_store.query.dataset_cache import (
+    get_disagg_aggr_dataset,
+    get_disagg_aggr_dataset_digest_vs30,
+    get_disagg_aggr_dataset_digest_vs30_nloc0,
+)
+from toshi_hazard_store.query.query_strategies import (
+    get_disagg_aggregates_by_digest_vs30,
+    get_disagg_aggregates_by_digest_vs30_nloc0,
+    get_disagg_aggregates_naive,
+)
+
+_BINS = {
+    "mag": ["5.5", "6.5", "7.5"],
+    "dist": ["10.0", "50.0", "100.0", "200.0"],
+    "eps": ["-1.0", "0.0", "1.0"],
+}
+_EXPECTED_SHAPE = tuple(len(v) for v in _BINS.values())
+_N_VALUES = math.prod(_EXPECTED_SHAPE)
+
+
+@pytest.fixture(autouse=True)
+def clear_disagg_dataset_caches():
+    """Clear disagg dataset caches before each test."""
+    get_disagg_aggr_dataset.cache_clear()
+    get_disagg_aggr_dataset_digest_vs30.cache_clear()
+    get_disagg_aggr_dataset_digest_vs30_nloc0.cache_clear()
+    yield
+
+
+@pytest.fixture(scope="module")
+def disagg_aggr_dataset(tmp_path_factory):
+    """Build a small disagg-aggregate parquet dataset partitioned by bins_digest/vs30/nloc_0."""
+    out = tmp_path_factory.mktemp("DISAGG_AGGR_SMALL")
+    digest = _bins_digest_from_dict(_BINS)
+
+    models = [
+        DisaggregationAggregate(
+            compatible_calc_id="NZSHM22",
+            hazard_model_id="NSHM_v1.0.4",
+            nloc_001=loc,
+            nloc_0=query.downsample_code(loc, 1.0),
+            vs30=vs30,
+            imt=imt,
+            target_aggr=target_aggr,
+            probability=ProbabilityEnum._10_PCT_IN_50YRS,
+            imtl=0.1,
+            aggr=aggr,
+            bins_digest=digest,
+            disagg_bins=_BINS,
+            disagg_values=[float(j) for j in range(_N_VALUES)],
+        )
+        for loc in ("-41.300~174.800", "-36.900~174.800")
+        for vs30 in (400, 1500)
+        for imt in ("PGA", "SA(0.5)")
+        for target_aggr in ("mean",)
+        for aggr in ("mean", "0.005")
+    ]
+
+    base_dir, fs_ = pyarrow_dataset.configure_output(str(out))
+    pyarrow_disagg_aggr_dataset.append_models_to_dataset(
+        models=iter(models),
+        base_dir=base_dir,
+        filesystem=fs_,
+        partitioning=["bins_digest", "vs30", "nloc_0"],
+    )
+
+    # Fail loudly if the writer PR uses a different partition layout.
+    assert (out / f"bins_digest={digest}" / "vs30=400").exists(), (
+        f"Expected partition layout bins_digest/vs30/nloc_0 not found under {out}. "
+        "Check that the disagg writer uses partitioning=['bins_digest', 'vs30', 'nloc_0']."
+    )
+
+    return out, digest
+
+
+@pytest.mark.parametrize(
+    "query_fn",
+    [
+        get_disagg_aggregates_naive,
+        get_disagg_aggregates_by_digest_vs30,
+        get_disagg_aggregates_by_digest_vs30_nloc0,
+        query.get_disagg_aggregates,
+    ],
+)
+@pytest.mark.parametrize("locn", ["-41.300~174.800", "-36.900~174.800"])
+@pytest.mark.parametrize("vs30", [400, 1500])
+@pytest.mark.parametrize("imt", ["PGA", "SA(0.5)"])
+@pytest.mark.parametrize("aggr", ["mean", "0.005"])
+def test_get_disagg_aggregates_from_dataset(disagg_aggr_dataset, query_fn, locn, vs30, imt, aggr):
+    """Happy-path: all 3 strategies and the wrapper return the correct disagg aggregate."""
+    dspath, digest = disagg_aggr_dataset
+
+    model = "NSHM_v1.0.4"
+    target_aggr = "mean"
+    prob = ProbabilityEnum._10_PCT_IN_50YRS
+
+    is_strategy = query_fn in (
+        get_disagg_aggregates_naive,
+        get_disagg_aggregates_by_digest_vs30,
+        get_disagg_aggregates_by_digest_vs30_nloc0,
+    )
+
+    if is_strategy:
+        result = query_fn(
+            location_codes=[locn],
+            vs30s=[vs30],
+            hazard_model=model,
+            imts=[imt],
+            aggs=[aggr],
+            target_aggrs=[target_aggr],
+            probabilities=[prob],
+            bins_digest=digest,
+            dataset_uri=str(dspath),
+        )
+    else:
+        result = query_fn(
+            location_codes=[locn],
+            vs30s=[vs30],
+            hazard_model=model,
+            imts=[imt],
+            aggs=[aggr],
+            target_aggrs=[target_aggr],
+            probabilities=[prob],
+            disagg_bins=_BINS,
+            dataset_uri=str(dspath),
+        )
+
+    res = next(result)
+
+    assert res.hazard_model_id == model
+    assert res.imt == imt
+    assert res.vs30 == vs30
+    assert res.aggr == aggr
+    assert res.target_aggr == target_aggr
+    assert res.probability == prob
+    assert res.bins_digest == digest
+    assert res.nloc_001 == locn
+    assert len(res.disagg_values) == _N_VALUES
+    assert res.to_ndarray().shape == _EXPECTED_SHAPE
+
+
+@pytest.mark.parametrize("bad_locn", ["-48.000~180.000"])
+@pytest.mark.parametrize("vs30", [400, 1500])
+@pytest.mark.parametrize("imt", ["PGA", "SA(0.5)"])
+@pytest.mark.parametrize("aggr", ["mean", "0.005"])
+def test_disagg_query_data_missing_for_one_location(monkeypatch, disagg_aggr_dataset, bad_locn, vs30, imt, aggr):
+    """d2 strategy raises deferred RuntimeWarning when a location partition is absent."""
+    dspath, digest = disagg_aggr_dataset
+    monkeypatch.setattr("toshi_hazard_store.query.dataset_cache.DATASET_DISAGG_AGGR_URI", str(dspath))
+
+    good_locn = "-41.300~174.800"
+
+    result = get_disagg_aggregates_by_digest_vs30_nloc0(
+        location_codes=[good_locn, bad_locn],
+        vs30s=[vs30],
+        hazard_model="NSHM_v1.0.4",
+        imts=[imt],
+        aggs=[aggr],
+        target_aggrs=["mean"],
+        probabilities=[ProbabilityEnum._10_PCT_IN_50YRS],
+        bins_digest=digest,
+    )
+
+    res = next(result)
+    assert res.hazard_model_id == "NSHM_v1.0.4"
+
+    with pytest.raises(RuntimeWarning, match=r".*Failed to open dataset.*"):
+        next(result)
+
+    with pytest.raises(StopIteration):
+        next(result)
+
+
+@pytest.mark.parametrize(
+    "query_fn",
+    [get_disagg_aggregates_by_digest_vs30, get_disagg_aggregates_by_digest_vs30_nloc0],
+)
+@pytest.mark.parametrize("bad_vs30", [401, 155])
+@pytest.mark.parametrize("imt", ["PGA", "SA(0.5)"])
+@pytest.mark.parametrize("aggr", ["mean", "0.005"])
+def test_disagg_query_data_missing_for_vs30(monkeypatch, disagg_aggr_dataset, query_fn, bad_vs30, imt, aggr):
+    """d1/d2 strategies raise deferred RuntimeWarning when a vs30 partition is absent."""
+    dspath, digest = disagg_aggr_dataset
+    monkeypatch.setattr("toshi_hazard_store.query.dataset_cache.DATASET_DISAGG_AGGR_URI", str(dspath))
+
+    result = query_fn(
+        location_codes=["-41.300~174.800"],
+        vs30s=[1500, bad_vs30],
+        hazard_model="NSHM_v1.0.4",
+        imts=[imt],
+        aggs=[aggr],
+        target_aggrs=["mean"],
+        probabilities=[ProbabilityEnum._10_PCT_IN_50YRS],
+        bins_digest=digest,
+    )
+
+    res = next(result)
+    assert res.hazard_model_id == "NSHM_v1.0.4"
+
+    with pytest.raises(RuntimeWarning, match=r".*Failed to open dataset.*"):
+        next(result)
+
+    with pytest.raises(StopIteration):
+        next(result)
+
+
+def test_disagg_query_bad_bins_digest_naive_yields_nothing(monkeypatch, disagg_aggr_dataset):
+    """Naive strategy with a wrong bins_digest column-filters to zero rows."""
+    dspath, _ = disagg_aggr_dataset
+    monkeypatch.setattr("toshi_hazard_store.query.dataset_cache.DATASET_DISAGG_AGGR_URI", str(dspath))
+
+    result = list(
+        get_disagg_aggregates_naive(
+            location_codes=["-41.300~174.800"],
+            vs30s=[400],
+            hazard_model="NSHM_v1.0.4",
+            imts=["PGA"],
+            aggs=["mean"],
+            target_aggrs=["mean"],
+            probabilities=[ProbabilityEnum._10_PCT_IN_50YRS],
+            bins_digest="0000000000000000",
+        )
+    )
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    "query_fn",
+    [get_disagg_aggregates_by_digest_vs30, get_disagg_aggregates_by_digest_vs30_nloc0],
+)
+def test_disagg_query_bad_bins_digest_d1_d2_raises_warning(monkeypatch, disagg_aggr_dataset, query_fn):
+    """d1/d2 strategies raise deferred RuntimeWarning when the bins_digest partition is absent."""
+    dspath, _ = disagg_aggr_dataset
+    monkeypatch.setattr("toshi_hazard_store.query.dataset_cache.DATASET_DISAGG_AGGR_URI", str(dspath))
+
+    result = query_fn(
+        location_codes=["-41.300~174.800"],
+        vs30s=[400],
+        hazard_model="NSHM_v1.0.4",
+        imts=["PGA"],
+        aggs=["mean"],
+        target_aggrs=["mean"],
+        probabilities=[ProbabilityEnum._10_PCT_IN_50YRS],
+        bins_digest="0000000000000000",
+    )
+
+    with pytest.raises(RuntimeWarning, match=r".*Failed to open dataset.*"):
+        next(result)
+
+    with pytest.raises(StopIteration):
+        next(result)
+
+
+def test_disagg_query_default_strategy_is_naive(monkeypatch):
+    """Wrapper uses the naive strategy when no strategy is specified."""
+    mocked_qry_fn = mock.Mock(return_value=[])
+    monkeypatch.setattr("toshi_hazard_store.query.datasets.get_disagg_aggregates_naive", mocked_qry_fn)
+
+    model = "NSHM_v1.0.4"
+    locn = "-41.300~174.800"
+    prob = ProbabilityEnum._10_PCT_IN_50YRS
+    digest = _bins_digest_from_dict(_BINS)
+
+    result = query.get_disagg_aggregates(
+        location_codes=[locn],
+        vs30s=[400],
+        hazard_model=model,
+        imts=["PGA"],
+        aggs=["mean"],
+        target_aggrs=["mean"],
+        probabilities=[prob],
+        disagg_bins=_BINS,
+    )
+
+    with pytest.raises(StopIteration):
+        next(result)
+
+    assert mocked_qry_fn.call_count == 1
+    mocked_qry_fn.assert_called_with([locn], [400], model, ["PGA"], ["mean"], ["mean"], [prob], digest, None)
+
+
+@pytest.mark.parametrize(
+    "strategy_fn_name",
+    [
+        ("d1", "get_disagg_aggregates_by_digest_vs30"),
+        ("d2", "get_disagg_aggregates_by_digest_vs30_nloc0"),
+        ("naive", "get_disagg_aggregates_naive"),
+        ("", "get_disagg_aggregates_naive"),
+    ],
+)
+def test_disagg_query_strategy_calls_correct_query_fn(monkeypatch, strategy_fn_name):
+    """Wrapper dispatches to the correct strategy function."""
+    mocked_qry_fn = mock.Mock(return_value=[])
+    monkeypatch.setattr(datasets_mod, strategy_fn_name[1], mocked_qry_fn)
+
+    model = "NSHM_v1.0.4"
+    locn = "-41.300~174.800"
+    prob = ProbabilityEnum._10_PCT_IN_50YRS
+    digest = _bins_digest_from_dict(_BINS)
+
+    result = query.get_disagg_aggregates(
+        location_codes=[locn],
+        vs30s=[400],
+        hazard_model=model,
+        imts=["PGA"],
+        aggs=["mean"],
+        target_aggrs=["mean"],
+        probabilities=[prob],
+        disagg_bins=_BINS,
+        strategy=strategy_fn_name[0],
+    )
+
+    with pytest.raises(StopIteration):
+        next(result)
+
+    assert mocked_qry_fn.call_count == 1
+    mocked_qry_fn.assert_called_with([locn], [400], model, ["PGA"], ["mean"], ["mean"], [prob], digest, None)
+
+
+@pytest.mark.parametrize("strategy", ["d1", "d2"])
+def test_disagg_query_strategy_unmocked(monkeypatch, disagg_aggr_dataset, strategy):
+    """d1 and d2 strategies raise RuntimeWarning when vs30 partition is absent."""
+    dspath, _ = disagg_aggr_dataset
+    monkeypatch.setattr("toshi_hazard_store.query.dataset_cache.DATASET_DISAGG_AGGR_URI", str(dspath))
+
+    result = query.get_disagg_aggregates(
+        location_codes=["-41.300~174.800"],
+        vs30s=[401],  # not in dataset
+        hazard_model="NSHM_v1.0.4",
+        imts=["PGA"],
+        aggs=["mean"],
+        target_aggrs=["mean"],
+        probabilities=[ProbabilityEnum._10_PCT_IN_50YRS],
+        disagg_bins=_BINS,
+        strategy=strategy,
+    )
+
+    with pytest.raises(RuntimeWarning, match=r".*Failed to open dataset.*"):
+        next(result)
+
+    with pytest.raises(StopIteration):
+        next(result)

--- a/toshi_hazard_store/__init__.py
+++ b/toshi_hazard_store/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """GNS Science"""
 __email__ = 'nshm@gns.cri.nz'
-__version__ = '1.5.0'
+__version__ = '2.0.0'
 
 
 import toshi_hazard_store.model as model

--- a/toshi_hazard_store/config.py
+++ b/toshi_hazard_store/config.py
@@ -35,3 +35,4 @@ ECR_REPONAME = "nzshm22/runzi-openquake"
 DATASET_AGGR_ENABLED = bool(os.getenv('THS_DATASET_AGGR_ENABLED', '').upper() in ["1", "Y", "YES", "TRUE"])
 DATASET_AGGR_URI = os.getenv('THS_DATASET_AGGR_URI', '')
 DATASET_GRIDDED_URI = os.getenv('THS_DATASET_GRIDDED_URI')
+DATASET_DISAGG_AGGR_URI = os.getenv('THS_DATASET_DISAGG_AGGR_URI', '')

--- a/toshi_hazard_store/model/hazard_models_pydantic.py
+++ b/toshi_hazard_store/model/hazard_models_pydantic.py
@@ -180,6 +180,12 @@ class DisaggregationAggregate(BaseModel):
             )
         return self
 
+    def to_ndarray(self):
+        """Reshape disagg_values into an N-D array with axes ordered by disagg_bins keys."""
+        from toshi_hazard_store.model.pyarrow.disagg_reshape import reshape_disagg_values
+
+        return reshape_disagg_values(self.disagg_values, self.disagg_bins)
+
     @staticmethod
     def pyarrow_schema() -> pa.schema:
         """A pyarrow schema for aggregate disaggregation datasets."""

--- a/toshi_hazard_store/model/revision_4/extract_disagg_hdf5.py
+++ b/toshi_hazard_store/model/revision_4/extract_disagg_hdf5.py
@@ -41,7 +41,7 @@ def _bins_digest_from_dict(payload: dict[str, list[str]]) -> str:
     retain insertion order for reshape.
     """
     normalised = {name: sorted(payload[name]) for name in sorted(payload)}
-    serialised = json.dumps(normalised, sort_keys=True, separators=(',', ':'))
+    serialised = json.dumps(normalised, separators=(',', ':'))
     return hashlib.sha256(serialised.encode()).hexdigest()[:16]
 
 

--- a/toshi_hazard_store/model/revision_4/extract_disagg_hdf5.py
+++ b/toshi_hazard_store/model/revision_4/extract_disagg_hdf5.py
@@ -30,6 +30,21 @@ log = logging.getLogger(__name__)
 _QUERY_DIMS = frozenset(('imt', 'poe'))
 
 
+def _bins_digest_from_dict(payload: dict[str, list[str]]) -> str:
+    """Return a 16-hex-char sha256 digest over a normalised disagg_bins dict.
+
+    Both axis-name keys and per-axis value lists are sorted so that reordering is
+    irrelevant. Values must already be in the stringified form used by the parquet
+    ``disagg_bins`` map column so that the HDF5 import path and the query path
+    produce identical digests for compatible bin structures.
+    Sorting here is purely to make the digest order-invariant; caller-side dicts
+    retain insertion order for reshape.
+    """
+    normalised = {name: sorted(payload[name]) for name in sorted(payload)}
+    serialised = json.dumps(normalised, sort_keys=True, separators=(',', ':'))
+    return hashlib.sha256(serialised.encode()).hexdigest()[:16]
+
+
 def compute_bins_digest(disagg_rlzs) -> str:
     """Return a short sha256 hex digest over the bin centres in a disagg extract result.
 
@@ -40,9 +55,8 @@ def compute_bins_digest(disagg_rlzs) -> str:
     the stored ``disagg_bins`` map).
     """
     axes = [str(d) for d in disagg_rlzs.shape_descr if str(d) not in _QUERY_DIMS]
-    payload = {name: sorted(_stringify_bin_centers(getattr(disagg_rlzs, name))) for name in sorted(axes)}
-    serialised = json.dumps(payload, sort_keys=True, separators=(',', ':'))
-    return hashlib.sha256(serialised.encode()).hexdigest()[:16]
+    payload = {name: _stringify_bin_centers(getattr(disagg_rlzs, name)) for name in axes}
+    return _bins_digest_from_dict(payload)
 
 
 def _stringify_bin_centers(values) -> list[str]:

--- a/toshi_hazard_store/query/__init__.py
+++ b/toshi_hazard_store/query/__init__.py
@@ -4,7 +4,7 @@ This package provides the main public interface for querying hazard data
 from parquet datasets. It includes:
 
 - Main query functions: get_hazard_curves, get_gridded_hazard, get_disagg_aggregates
-- Data models: AggregatedHazard, AggregatedDisagg, IMTValue
+- Data models: AggregatedHazard, DisaggregationAggregate, IMTValue
 - Location utilities: downsample_code, get_hashes
 
 """
@@ -15,6 +15,8 @@ from parquet datasets. It includes:
 # # Dataset cache accessors (for advanced use)
 # from .dataset_cache import get_dataset, get_dataset_vs30, get_dataset_vs30_nloc0, get_gridded_dataset
 
+from toshi_hazard_store.model.hazard_models_pydantic import DisaggregationAggregate
+
 # Main query functions
 from .datasets import get_disagg_aggregates, get_gridded_hazard, get_hazard_curves
 
@@ -22,7 +24,7 @@ from .datasets import get_disagg_aggregates, get_gridded_hazard, get_hazard_curv
 from .hazard_query import downsample_code, get_hashes
 
 # Data models
-from .models import AggregatedDisagg, AggregatedHazard, IMTValue
+from .models import AggregatedHazard, IMTValue
 
 __all__ = [
     # Main query functions
@@ -31,7 +33,7 @@ __all__ = [
     "get_disagg_aggregates",
     # Data models
     "AggregatedHazard",
-    "AggregatedDisagg",
+    "DisaggregationAggregate",
     "IMTValue",
     # Location utilities
     "downsample_code",

--- a/toshi_hazard_store/query/__init__.py
+++ b/toshi_hazard_store/query/__init__.py
@@ -3,8 +3,8 @@
 This package provides the main public interface for querying hazard data
 from parquet datasets. It includes:
 
-- Main query functions: get_hazard_curves, get_gridded_hazard
-- Data models: AggregatedHazard, IMTValue
+- Main query functions: get_hazard_curves, get_gridded_hazard, get_disagg_aggregates
+- Data models: AggregatedHazard, AggregatedDisagg, IMTValue
 - Location utilities: downsample_code, get_hashes
 
 """
@@ -16,20 +16,22 @@ from parquet datasets. It includes:
 # from .dataset_cache import get_dataset, get_dataset_vs30, get_dataset_vs30_nloc0, get_gridded_dataset
 
 # Main query functions
-from .datasets import get_gridded_hazard, get_hazard_curves
+from .datasets import get_disagg_aggregates, get_gridded_hazard, get_hazard_curves
 
 # Location utilities
 from .hazard_query import downsample_code, get_hashes
 
 # Data models
-from .models import AggregatedHazard, IMTValue
+from .models import AggregatedDisagg, AggregatedHazard, IMTValue
 
 __all__ = [
     # Main query functions
     "get_hazard_curves",
     "get_gridded_hazard",
+    "get_disagg_aggregates",
     # Data models
     "AggregatedHazard",
+    "AggregatedDisagg",
     "IMTValue",
     # Location utilities
     "downsample_code",

--- a/toshi_hazard_store/query/dataset_cache.py
+++ b/toshi_hazard_store/query/dataset_cache.py
@@ -5,17 +5,61 @@ import logging
 from functools import lru_cache
 from typing import Optional
 
+import pyarrow as pa
 import pyarrow.dataset as ds
 
-from toshi_hazard_store.config import DATASET_AGGR_URI, DATASET_GRIDDED_URI
+from toshi_hazard_store.config import DATASET_AGGR_URI, DATASET_DISAGG_AGGR_URI, DATASET_GRIDDED_URI
 from toshi_hazard_store.model.gridded.gridded_hazard_pydantic import GriddedHazardPoeLevels
-from toshi_hazard_store.model.hazard_models_pydantic import HazardAggregateCurve
+from toshi_hazard_store.model.hazard_models_pydantic import DisaggregationAggregate, HazardAggregateCurve
 from toshi_hazard_store.model.pyarrow import pyarrow_dataset
 from toshi_hazard_store.query.hazard_query import downsample_code
 
 log = logging.getLogger(__name__)
 
 GB = 1024**3
+
+
+def _plain_schema(schema: pa.Schema) -> pa.Schema:
+    """Return a copy of schema with all dictionary-encoded fields replaced by their value type.
+
+    Hive partition values are read as plain strings from the path, so pyarrow cannot match
+    them to dictionary fields unless the dictionary is pre-populated. Stripping the encoding
+    here lets ds.dataset() discover and open the dataset correctly; parquet files are still
+    read with their native dictionary encoding.
+    """
+    return pa.schema(
+        [pa.field(f.name, f.type.value_type if pa.types.is_dictionary(f.type) else f.type) for f in schema]
+    )
+
+
+def _open_partitioned_dataset(base_uri: str, schema: pa.Schema, parts: list[tuple[str, str]]) -> ds.Dataset:
+    """Open a hive-partitioned parquet dataset at <base_uri>/{k}={v}/{k}={v}/...
+
+    Wraps ds.dataset() in a try/except that raises RuntimeError with the substring
+    'Failed to open dataset' so the query wrapper's deferred-warning pattern matches.
+    """
+    start_time = dt.datetime.now()
+    source_dir, source_filesystem = pyarrow_dataset.configure_output(base_uri)
+    suffix = "/".join(f"{k}={v}" for k, v in parts)
+    dspath = f"{source_dir}/{suffix}" if suffix else source_dir
+    log.debug(f"Opening dataset at `{dspath}`")
+    try:
+        dataset = ds.dataset(
+            dspath,
+            filesystem=source_filesystem,
+            partitioning="hive",
+            format="parquet",
+            schema=_plain_schema(schema),
+        )
+        log.info(f"Opened dataset `{dataset}` in {dt.datetime.now() - start_time}.")
+    except Exception as e:
+        raise RuntimeError(f"Failed to open dataset: {e}")
+    return dataset
+
+
+# ---------------------------------------------------------------------------
+# Hazard aggregate curve accessors
+# ---------------------------------------------------------------------------
 
 
 @lru_cache(maxsize=1)
@@ -29,40 +73,21 @@ def get_dataset(dataset_uri: Optional[str] = None) -> ds.Dataset:
     Returns:
       A pyarrow.dataset.Dataset object.
     """
-    start_time = dt.datetime.now()
-    ds_uri = dataset_uri or DATASET_AGGR_URI
-    try:
-        source_dir, source_filesystem = pyarrow_dataset.configure_output(ds_uri)
-        dataset = ds.dataset(
-            source_dir,
-            filesystem=source_filesystem,
-            partitioning="hive",
-            format="parquet",
-            schema=HazardAggregateCurve.pyarrow_schema(),
-        )
-        log.info(f"Opened dataset `{dataset}` in {dt.datetime.now() - start_time}.")
-    except Exception as e:  # pragma: no cover
-        raise RuntimeError(f"Failed to open dataset: {e}")
-    return dataset
+    return _open_partitioned_dataset(
+        dataset_uri or DATASET_AGGR_URI,
+        HazardAggregateCurve.pyarrow_schema(),
+        [],
+    )
 
 
 @lru_cache(maxsize=1)
 def get_gridded_dataset(dataset_uri: Optional[str] = None) -> ds.Dataset:
-    start_time = dt.datetime.now()
     ds_uri = dataset_uri or DATASET_GRIDDED_URI
-    try:
-        source_dir, source_filesystem = pyarrow_dataset.configure_output(str(ds_uri))
-        dataset = ds.dataset(
-            source_dir,
-            filesystem=source_filesystem,
-            partitioning="hive",
-            format="parquet",
-            schema=GriddedHazardPoeLevels.pyarrow_schema(),
-        )
-        log.info(f"Opened dataset `{dataset}` in {dt.datetime.now() - start_time}.")
-    except Exception as e:  # pragma: no cover
-        raise RuntimeError(f"Failed to open dataset: {e}")
-    return dataset
+    return _open_partitioned_dataset(
+        str(ds_uri),
+        GriddedHazardPoeLevels.pyarrow_schema(),
+        [],
+    )
 
 
 @lru_cache(maxsize=3)
@@ -77,22 +102,11 @@ def get_dataset_vs30(vs30: int, dataset_uri: Optional[str] = None) -> ds.Dataset
     Returns:
       A pyarrow.dataset.Dataset object.
     """
-    start_time = dt.datetime.now()
-    ds_uri = dataset_uri or DATASET_AGGR_URI
-    try:
-        source_dir, source_filesystem = pyarrow_dataset.configure_output(ds_uri)
-        dspath = f"{source_dir}/vs30={vs30}"
-        dataset = ds.dataset(
-            dspath,
-            filesystem=source_filesystem,
-            partitioning="hive",
-            format="parquet",
-            schema=HazardAggregateCurve.pyarrow_schema(),
-        )
-        log.info(f"Opened dataset `{dataset}` in {dt.datetime.now() - start_time}.")
-    except Exception as e:  # pragma: no cover
-        raise RuntimeError(f"Failed to open dataset: {e}")
-    return dataset
+    return _open_partitioned_dataset(
+        dataset_uri or DATASET_AGGR_URI,
+        HazardAggregateCurve.pyarrow_schema(),
+        [("vs30", str(vs30))],
+    )
 
 
 @lru_cache(maxsize=32)
@@ -108,21 +122,76 @@ def get_dataset_vs30_nloc0(vs30: int, nloc: str, dataset_uri: Optional[str] = No
     Returns:
       A pyarrow.dataset.Dataset object.
     """
-    start_time = dt.datetime.now()
-    ds_uri = dataset_uri or DATASET_AGGR_URI
-    try:
-        source_dir, source_filesystem = pyarrow_dataset.configure_output(ds_uri)
-        log.debug(f"source_dir:`{source_dir}`, filesystem: `{source_filesystem}`")
-        dspath = f"{source_dir}/vs30={vs30}/nloc_0={downsample_code(nloc, 1.0)}"
-        log.debug(f"Opening dspath :`{dspath}`")
-        dataset = ds.dataset(
-            dspath,
-            filesystem=source_filesystem,
-            partitioning="hive",
-            format="parquet",
-            schema=HazardAggregateCurve.pyarrow_schema(),
-        )
-        log.info(f"Opened dataset `{dataset}` in {dt.datetime.now() - start_time}.")
-    except Exception as e:  # pragma: no cover
-        raise RuntimeError(f"Failed to open dataset: {e}")
-    return dataset
+    return _open_partitioned_dataset(
+        dataset_uri or DATASET_AGGR_URI,
+        HazardAggregateCurve.pyarrow_schema(),
+        [("vs30", str(vs30)), ("nloc_0", downsample_code(nloc, 1.0))],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Disaggregation aggregate accessors
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def get_disagg_aggr_dataset(dataset_uri: Optional[str] = None) -> ds.Dataset:
+    """
+    Cache the disaggregation aggregate dataset.
+
+    Args:
+      dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
+
+    Returns:
+      A pyarrow.dataset.Dataset object.
+    """
+    return _open_partitioned_dataset(
+        dataset_uri or DATASET_DISAGG_AGGR_URI,
+        DisaggregationAggregate.pyarrow_schema(),
+        [],
+    )
+
+
+@lru_cache(maxsize=3)
+def get_disagg_aggr_dataset_digest_vs30(
+    bins_digest: str, vs30: int, dataset_uri: Optional[str] = None
+) -> ds.Dataset:
+    """
+    Cache the disaggregation aggregate dataset for a given bins_digest and vs30.
+
+    Args:
+      bins_digest: the bins compatibility digest to partition on.
+      vs30: the VS30 value to partition on.
+      dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
+
+    Returns:
+      A pyarrow.dataset.Dataset object.
+    """
+    return _open_partitioned_dataset(
+        dataset_uri or DATASET_DISAGG_AGGR_URI,
+        DisaggregationAggregate.pyarrow_schema(),
+        [("bins_digest", bins_digest), ("vs30", str(vs30))],
+    )
+
+
+@lru_cache(maxsize=32)
+def get_disagg_aggr_dataset_digest_vs30_nloc0(
+    bins_digest: str, vs30: int, nloc: str, dataset_uri: Optional[str] = None
+) -> ds.Dataset:
+    """
+    Cache the disaggregation aggregate dataset for a given bins_digest, vs30, and nloc_0.
+
+    Args:
+      bins_digest: the bins compatibility digest to partition on.
+      vs30: the VS30 value to partition on.
+      nloc: the nloc_0 location code to partition on.
+      dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
+
+    Returns:
+      A pyarrow.dataset.Dataset object.
+    """
+    return _open_partitioned_dataset(
+        dataset_uri or DATASET_DISAGG_AGGR_URI,
+        DisaggregationAggregate.pyarrow_schema(),
+        [("bins_digest", bins_digest), ("vs30", str(vs30)), ("nloc_0", downsample_code(nloc, 1.0))],
+    )

--- a/toshi_hazard_store/query/datasets.py
+++ b/toshi_hazard_store/query/datasets.py
@@ -8,9 +8,10 @@ import pyarrow.compute as pc
 
 from toshi_hazard_store.model.constraints import ProbabilityEnum
 from toshi_hazard_store.model.gridded.gridded_hazard_pydantic import GriddedHazardPoeLevels
+from toshi_hazard_store.model.hazard_models_pydantic import DisaggregationAggregate
 from toshi_hazard_store.model.revision_4.extract_disagg_hdf5 import _bins_digest_from_dict
 from toshi_hazard_store.query.dataset_cache import get_gridded_dataset
-from toshi_hazard_store.query.models import AggregatedDisagg, AggregatedHazard
+from toshi_hazard_store.query.models import AggregatedHazard
 from toshi_hazard_store.query.query_strategies import (
     get_disagg_aggregates_by_digest_vs30,
     get_disagg_aggregates_by_digest_vs30_nloc0,
@@ -164,7 +165,7 @@ def get_disagg_aggregates(
     disagg_bins: dict[str, list[str]],
     strategy: str = "naive",
     dataset_uri: Optional[str] = None,
-) -> Iterator[AggregatedDisagg]:
+) -> Iterator[DisaggregationAggregate]:
     """
     Retrieves aggregated disaggregations from the dataset.
 
@@ -189,7 +190,7 @@ def get_disagg_aggregates(
       dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
 
     Yields:
-      AggregatedDisagg: An object containing the disaggregation aggregate data.
+      DisaggregationAggregate: An object containing the disaggregation aggregate data.
     Raises:
       RuntimeWarning: describing any dataset partitions that could not be opened.
     """

--- a/toshi_hazard_store/query/datasets.py
+++ b/toshi_hazard_store/query/datasets.py
@@ -6,10 +6,15 @@ from typing import Iterator, Optional
 
 import pyarrow.compute as pc
 
+from toshi_hazard_store.model.constraints import ProbabilityEnum
 from toshi_hazard_store.model.gridded.gridded_hazard_pydantic import GriddedHazardPoeLevels
+from toshi_hazard_store.model.revision_4.extract_disagg_hdf5 import _bins_digest_from_dict
 from toshi_hazard_store.query.dataset_cache import get_gridded_dataset
-from toshi_hazard_store.query.models import AggregatedHazard
+from toshi_hazard_store.query.models import AggregatedDisagg, AggregatedHazard
 from toshi_hazard_store.query.query_strategies import (
+    get_disagg_aggregates_by_digest_vs30,
+    get_disagg_aggregates_by_digest_vs30_nloc0,
+    get_disagg_aggregates_naive,
     get_hazard_curves_by_vs30,
     get_hazard_curves_by_vs30_nloc0,
     get_hazard_curves_naive,
@@ -146,3 +151,76 @@ def get_gridded_hazard(
         # yield GriddedHazardPoeLevels(**row_dict) # SLOW because of the expensive validators on
         # this Pydantic Model class.
         yield GriddedHazardPoeLevels.model_construct(**row_dict)  # FAST
+
+
+def get_disagg_aggregates(
+    location_codes: list[str],
+    vs30s: list[int],
+    hazard_model: str,
+    imts: list[str],
+    aggs: list[str],
+    target_aggrs: list[str],
+    probabilities: list[ProbabilityEnum],
+    disagg_bins: dict[str, list[str]],
+    strategy: str = "naive",
+    dataset_uri: Optional[str] = None,
+) -> Iterator[AggregatedDisagg]:
+    """
+    Retrieves aggregated disaggregations from the dataset.
+
+    The optional `strategy` argument can be used to control how the query behaves:
+
+     - 'naive' (the default) lets pyarrow do its normal thing.
+     - 'd1' assumes the dataset is partitioned on `bins_digest, vs30`.
+     - 'd2' assumes the dataset is partitioned on `bins_digest, vs30, nloc_0` and acts accordingly.
+
+    Args:
+      location_codes (list): List of location codes.
+      vs30s (list): List of VS30 values.
+      hazard_model: the hazard model id.
+      imts (list): List of intensity measure types (e.g. 'PGA', 'SA(5.0)').
+      aggs (list): List of aggregation types.
+      target_aggrs (list): List of target hazard-curve aggregation types (e.g. 'mean', '0.5').
+      probabilities (list): List of ProbabilityEnum members.
+      disagg_bins: the bins dict defining the disaggregation topology. The bins compatibility
+          digest is computed internally from this dict.
+      strategy: which query strategy to use (options are `d1`, `d2`, `naive`).
+          Other values will use the `naive` strategy.
+      dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
+
+    Yields:
+      AggregatedDisagg: An object containing the disaggregation aggregate data.
+    Raises:
+      RuntimeWarning: describing any dataset partitions that could not be opened.
+    """
+    log.debug("> get_disagg_aggregates()")
+    t0 = dt.datetime.now()
+
+    count = 0
+    bins_digest = _bins_digest_from_dict(disagg_bins)
+
+    if strategy == "d2":
+        qfn = get_disagg_aggregates_by_digest_vs30_nloc0
+    elif strategy == "d1":
+        qfn = get_disagg_aggregates_by_digest_vs30
+    else:
+        qfn = get_disagg_aggregates_naive
+
+    deferred_warning = None
+    try:
+        for obj in qfn(  # pragma: no branch
+            location_codes, vs30s, hazard_model, imts, aggs, target_aggrs, probabilities, bins_digest, dataset_uri
+        ):
+            count += 1
+            yield obj
+    except RuntimeWarning as err:
+        if "Failed to open dataset" in str(err):
+            deferred_warning = err
+        else:
+            raise err  # pragma: no cover
+
+    t1 = dt.datetime.now()
+    log.info(f"Executed dataset query for {count} disaggs in {(t1 - t0).total_seconds()} seconds.")
+
+    if deferred_warning:  # pragma: no cover
+        raise deferred_warning

--- a/toshi_hazard_store/query/models.py
+++ b/toshi_hazard_store/query/models.py
@@ -2,6 +2,10 @@
 
 from dataclasses import dataclass
 
+from pydantic import BaseModel
+
+from toshi_hazard_store.model.constraints import ProbabilityEnum
+
 # Constants
 IMT_44_LVLS = [
     0.0001,
@@ -103,3 +107,47 @@ class AggregatedHazard:
         new_values = zip(IMT_44_LVLS, self.values)
         self.values = [IMTValue(*x) for x in new_values]
         return self
+
+
+class AggregatedDisagg(BaseModel):
+    """Row from the aggregate-disaggregation parquet dataset.
+
+    Attributes:
+        compatible_calc_id: ID of a compatible calculation for PSHA engine interoperability.
+        hazard_model_id: the NSHM hazard model identifier.
+        bins_digest: sha256[:16] compatibility key over sorted axes + bin centres.
+        nloc_001: location code at 0.001° resolution e.g. "-38.330~175.550".
+        nloc_0: location code at 1.0° resolution (partition key).
+        vs30: VS30 value in m/s.
+        imt: intensity measure type label e.g. 'PGA', 'SA(1.0)'.
+        target_aggr: hazard-curve aggregation the disagg was conditioned on e.g. 'mean'.
+        probability: the return-period probability as a ProbabilityEnum member.
+        imtl: IML at which the disagg was computed.
+        aggr: aggregation type across realisations e.g. 'mean', '0.1'.
+        disagg_bins: ordered map of axis name to list of bin-centre strings.
+        disagg_values: flattened C-order disaggregation array (use to_ndarray() to reshape).
+
+    Notes:
+        Constructed at query time via model_construct() (skips validators) for performance.
+        disagg_values is kept flat per project convention; reshape is opt-in via to_ndarray().
+    """
+
+    compatible_calc_id: str
+    hazard_model_id: str
+    bins_digest: str
+    nloc_001: str
+    nloc_0: str
+    vs30: int
+    imt: str
+    target_aggr: str
+    probability: ProbabilityEnum
+    imtl: float
+    aggr: str
+    disagg_bins: dict[str, list[str]]
+    disagg_values: list[float]
+
+    def to_ndarray(self):
+        """Reshape disagg_values into an N-D array with axes ordered by disagg_bins keys."""
+        from toshi_hazard_store.model.pyarrow.disagg_reshape import reshape_disagg_values
+
+        return reshape_disagg_values(self.disagg_values, self.disagg_bins)

--- a/toshi_hazard_store/query/models.py
+++ b/toshi_hazard_store/query/models.py
@@ -2,10 +2,6 @@
 
 from dataclasses import dataclass
 
-from pydantic import BaseModel
-
-from toshi_hazard_store.model.constraints import ProbabilityEnum
-
 # Constants
 IMT_44_LVLS = [
     0.0001,
@@ -109,45 +105,3 @@ class AggregatedHazard:
         return self
 
 
-class AggregatedDisagg(BaseModel):
-    """Row from the aggregate-disaggregation parquet dataset.
-
-    Attributes:
-        compatible_calc_id: ID of a compatible calculation for PSHA engine interoperability.
-        hazard_model_id: the NSHM hazard model identifier.
-        bins_digest: sha256[:16] compatibility key over sorted axes + bin centres.
-        nloc_001: location code at 0.001° resolution e.g. "-38.330~175.550".
-        nloc_0: location code at 1.0° resolution (partition key).
-        vs30: VS30 value in m/s.
-        imt: intensity measure type label e.g. 'PGA', 'SA(1.0)'.
-        target_aggr: hazard-curve aggregation the disagg was conditioned on e.g. 'mean'.
-        probability: the return-period probability as a ProbabilityEnum member.
-        imtl: IML at which the disagg was computed.
-        aggr: aggregation type across realisations e.g. 'mean', '0.1'.
-        disagg_bins: ordered map of axis name to list of bin-centre strings.
-        disagg_values: flattened C-order disaggregation array (use to_ndarray() to reshape).
-
-    Notes:
-        Constructed at query time via model_construct() (skips validators) for performance.
-        disagg_values is kept flat per project convention; reshape is opt-in via to_ndarray().
-    """
-
-    compatible_calc_id: str
-    hazard_model_id: str
-    bins_digest: str
-    nloc_001: str
-    nloc_0: str
-    vs30: int
-    imt: str
-    target_aggr: str
-    probability: ProbabilityEnum
-    imtl: float
-    aggr: str
-    disagg_bins: dict[str, list[str]]
-    disagg_values: list[float]
-
-    def to_ndarray(self):
-        """Reshape disagg_values into an N-D array with axes ordered by disagg_bins keys."""
-        from toshi_hazard_store.model.pyarrow.disagg_reshape import reshape_disagg_values
-
-        return reshape_disagg_values(self.disagg_values, self.disagg_bins)

--- a/toshi_hazard_store/query/query_strategies.py
+++ b/toshi_hazard_store/query/query_strategies.py
@@ -8,6 +8,7 @@ from typing import Iterator, Optional
 import pyarrow.compute as pc
 
 from toshi_hazard_store.model.constraints import ProbabilityEnum
+from toshi_hazard_store.model.hazard_models_pydantic import DisaggregationAggregate
 from toshi_hazard_store.query.dataset_cache import (
     get_dataset,
     get_dataset_vs30,
@@ -17,7 +18,7 @@ from toshi_hazard_store.query.dataset_cache import (
     get_disagg_aggr_dataset_digest_vs30_nloc0,
 )
 from toshi_hazard_store.query.hazard_query import downsample_code, get_hashes
-from toshi_hazard_store.query.models import AggregatedDisagg, AggregatedHazard
+from toshi_hazard_store.query.models import AggregatedHazard
 
 log = logging.getLogger(__name__)
 
@@ -249,7 +250,7 @@ def get_disagg_aggregates_naive(
     probabilities: list[ProbabilityEnum],
     bins_digest: str,
     dataset_uri: Optional[str] = None,
-) -> Iterator[AggregatedDisagg]:
+) -> Iterator[DisaggregationAggregate]:
     """
     Retrieves aggregated disaggregations from the dataset using a single filter.
 
@@ -265,7 +266,7 @@ def get_disagg_aggregates_naive(
       dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
 
     Yields:
-      AggregatedDisagg: An object containing disaggregation aggregate data.
+      DisaggregationAggregate: An object containing disaggregation aggregate data.
     """
     log.debug(f"> get_disagg_aggregates_naive() location_codes: {location_codes}")
     t0 = dt.datetime.now()
@@ -295,7 +296,7 @@ def get_disagg_aggregates_naive(
     for row_dict in df.to_dict(orient="records"):
         count += 1
         row_dict["probability"] = ProbabilityEnum[row_dict["probability"]]
-        yield AggregatedDisagg.model_construct(**row_dict)
+        yield DisaggregationAggregate.model_construct(**row_dict)
 
     log.debug(f"Executed dataset query for {count} disaggs in {(dt.datetime.now() - t0).total_seconds()} seconds.")
 
@@ -310,7 +311,7 @@ def get_disagg_aggregates_by_digest_vs30(
     probabilities: list[ProbabilityEnum],
     bins_digest: str,
     dataset_uri: Optional[str] = None,
-) -> Iterator[AggregatedDisagg]:
+) -> Iterator[DisaggregationAggregate]:
     """
     Retrieves aggregated disaggregations using bins_digest and vs30 partition pruning.
 
@@ -326,7 +327,7 @@ def get_disagg_aggregates_by_digest_vs30(
       dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
 
     Yields:
-      AggregatedDisagg: An object containing disaggregation aggregate data.
+      DisaggregationAggregate: An object containing disaggregation aggregate data.
 
     Raises:
       RuntimeWarning: describing any dataset partitions that could not be opened.
@@ -366,7 +367,7 @@ def get_disagg_aggregates_by_digest_vs30(
             row_dict["probability"] = ProbabilityEnum[row_dict["probability"]]
             row_dict["bins_digest"] = bins_digest
             row_dict["vs30"] = vs30
-            yield AggregatedDisagg.model_construct(**row_dict)
+            yield DisaggregationAggregate.model_construct(**row_dict)
 
         log.debug(f"Executed dataset query for {count} disaggs in {(dt.datetime.now() - t0).total_seconds()} seconds.")
 
@@ -384,7 +385,7 @@ def get_disagg_aggregates_by_digest_vs30_nloc0(
     probabilities: list[ProbabilityEnum],
     bins_digest: str,
     dataset_uri: Optional[str] = None,
-) -> Iterator[AggregatedDisagg]:
+) -> Iterator[DisaggregationAggregate]:
     """
     Retrieves aggregated disaggregations using bins_digest, vs30, and nloc_0 partition pruning.
 
@@ -400,7 +401,7 @@ def get_disagg_aggregates_by_digest_vs30_nloc0(
       dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
 
     Yields:
-      AggregatedDisagg: An object containing disaggregation aggregate data.
+      DisaggregationAggregate: An object containing disaggregation aggregate data.
 
     Raises:
       RuntimeWarning: describing any dataset partitions that could not be opened.
@@ -451,7 +452,7 @@ def get_disagg_aggregates_by_digest_vs30_nloc0(
                 row_dict["bins_digest"] = bins_digest
                 row_dict["vs30"] = vs30
                 row_dict["nloc_0"] = downsample_code(hloc, 1.0)
-                yield AggregatedDisagg.model_construct(**row_dict)
+                yield DisaggregationAggregate.model_construct(**row_dict)
 
         log.debug(f"Executed dataset query for {count} disaggs in {(dt.datetime.now() - t0).total_seconds()} seconds.")
 

--- a/toshi_hazard_store/query/query_strategies.py
+++ b/toshi_hazard_store/query/query_strategies.py
@@ -1,4 +1,4 @@
-"""Different query strategies for hazard curve retrieval."""
+"""Different query strategies for hazard curve and disaggregation aggregate retrieval."""
 
 import datetime as dt
 import itertools
@@ -7,9 +7,17 @@ from typing import Iterator, Optional
 
 import pyarrow.compute as pc
 
-from toshi_hazard_store.query.dataset_cache import get_dataset, get_dataset_vs30, get_dataset_vs30_nloc0
+from toshi_hazard_store.model.constraints import ProbabilityEnum
+from toshi_hazard_store.query.dataset_cache import (
+    get_dataset,
+    get_dataset_vs30,
+    get_dataset_vs30_nloc0,
+    get_disagg_aggr_dataset,
+    get_disagg_aggr_dataset_digest_vs30,
+    get_disagg_aggr_dataset_digest_vs30_nloc0,
+)
 from toshi_hazard_store.query.hazard_query import downsample_code, get_hashes
-from toshi_hazard_store.query.models import AggregatedHazard
+from toshi_hazard_store.query.models import AggregatedDisagg, AggregatedHazard
 
 log = logging.getLogger(__name__)
 
@@ -221,6 +229,231 @@ def get_hazard_curves_by_vs30_nloc0(
 
         t3 = dt.datetime.now()  # pragma: no cover
         log.debug(f"Executed dataset query for {count} curves in {(t3 - t0).total_seconds()} seconds.")
+
+    if dataset_exceptions:  # pragma: no branch
+        raise RuntimeWarning(f"Dataset errors: {dataset_exceptions}")
+
+
+# ---------------------------------------------------------------------------
+# Disaggregation aggregate strategies
+# ---------------------------------------------------------------------------
+
+
+def get_disagg_aggregates_naive(
+    location_codes: list[str],
+    vs30s: list[int],
+    hazard_model: str,
+    imts: list[str],
+    aggs: list[str],
+    target_aggrs: list[str],
+    probabilities: list[ProbabilityEnum],
+    bins_digest: str,
+    dataset_uri: Optional[str] = None,
+) -> Iterator[AggregatedDisagg]:
+    """
+    Retrieves aggregated disaggregations from the dataset using a single filter.
+
+    Args:
+      location_codes (list): List of location codes.
+      vs30s (list): List of VS30 values.
+      hazard_model: the hazard model id.
+      imts (list): List of intensity measure types.
+      aggs (list): List of aggregation types.
+      target_aggrs (list): List of target hazard-curve aggregation types.
+      probabilities (list): List of ProbabilityEnum members.
+      bins_digest: pre-computed bins compatibility digest.
+      dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
+
+    Yields:
+      AggregatedDisagg: An object containing disaggregation aggregate data.
+    """
+    log.debug(f"> get_disagg_aggregates_naive() location_codes: {location_codes}")
+    t0 = dt.datetime.now()
+
+    dataset = get_disagg_aggr_dataset(dataset_uri)
+    nloc_001_locs = [downsample_code(loc, 0.001) for loc in location_codes]
+    prob_names = [p.name for p in probabilities]
+    flt = (
+        (pc.field("bins_digest") == bins_digest)
+        & (pc.field("aggr").isin(aggs))
+        & (pc.field("target_aggr").isin(target_aggrs))
+        & (pc.field("nloc_0").isin(get_hashes(location_codes, resolution=1)))
+        & (pc.field("nloc_001").isin(nloc_001_locs))
+        & (pc.field("imt").isin(imts))
+        & (pc.field("vs30").isin(vs30s))
+        & (pc.field("hazard_model_id") == hazard_model)
+        & (pc.field("probability").isin(prob_names))
+    )
+    log.debug(f"filter: {flt}")
+    table = dataset.to_table(filter=flt)
+
+    t1 = dt.datetime.now()
+    log.debug(f"to_table for filter took {(t1 - t0).total_seconds()} seconds.")
+
+    count = 0
+    df = table.to_pandas()
+    for row_dict in df.to_dict(orient="records"):
+        count += 1
+        row_dict["probability"] = ProbabilityEnum[row_dict["probability"]]
+        yield AggregatedDisagg.model_construct(**row_dict)
+
+    log.debug(f"Executed dataset query for {count} disaggs in {(dt.datetime.now() - t0).total_seconds()} seconds.")
+
+
+def get_disagg_aggregates_by_digest_vs30(
+    location_codes: list[str],
+    vs30s: list[int],
+    hazard_model: str,
+    imts: list[str],
+    aggs: list[str],
+    target_aggrs: list[str],
+    probabilities: list[ProbabilityEnum],
+    bins_digest: str,
+    dataset_uri: Optional[str] = None,
+) -> Iterator[AggregatedDisagg]:
+    """
+    Retrieves aggregated disaggregations using bins_digest and vs30 partition pruning.
+
+    Args:
+      location_codes (list): List of location codes.
+      vs30s (list): List of VS30 values.
+      hazard_model: the hazard model id.
+      imts (list): List of intensity measure types.
+      aggs (list): List of aggregation types.
+      target_aggrs (list): List of target hazard-curve aggregation types.
+      probabilities (list): List of ProbabilityEnum members.
+      bins_digest: pre-computed bins compatibility digest.
+      dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
+
+    Yields:
+      AggregatedDisagg: An object containing disaggregation aggregate data.
+
+    Raises:
+      RuntimeWarning: describing any dataset partitions that could not be opened.
+    """
+    log.debug(f"> get_disagg_aggregates_by_digest_vs30({location_codes}, {vs30s},...)")
+    t0 = dt.datetime.now()
+
+    dataset_exceptions = []
+    nloc_001_locs = [downsample_code(loc, 0.001) for loc in location_codes]
+    prob_names = [p.name for p in probabilities]
+
+    for vs30 in vs30s:  # pragma: no branch
+        count = 0
+        try:
+            dataset = get_disagg_aggr_dataset_digest_vs30(bins_digest, vs30, dataset_uri)
+        except Exception:
+            dataset_exceptions.append(f"Failed to open dataset for bins_digest={bins_digest}, vs30={vs30}")
+            continue
+
+        flt = (
+            (pc.field("aggr").isin(aggs))
+            & (pc.field("target_aggr").isin(target_aggrs))
+            & (pc.field("nloc_0").isin(get_hashes(location_codes, resolution=1)))
+            & (pc.field("nloc_001").isin(nloc_001_locs))
+            & (pc.field("imt").isin(imts))
+            & (pc.field("hazard_model_id") == hazard_model)
+            & (pc.field("probability").isin(prob_names))
+        )
+        log.debug(f"filter: {flt}")
+        table = dataset.to_table(filter=flt)
+        t1 = dt.datetime.now()
+        log.debug(f"to_table for filter took {(t1 - t0).total_seconds()} seconds.")
+
+        df = table.to_pandas()
+        for row_dict in df.to_dict(orient="records"):
+            count += 1
+            row_dict["probability"] = ProbabilityEnum[row_dict["probability"]]
+            row_dict["bins_digest"] = bins_digest
+            row_dict["vs30"] = vs30
+            yield AggregatedDisagg.model_construct(**row_dict)
+
+        log.debug(f"Executed dataset query for {count} disaggs in {(dt.datetime.now() - t0).total_seconds()} seconds.")
+
+    if dataset_exceptions:  # pragma: no branch
+        raise RuntimeWarning(f"Dataset errors: {dataset_exceptions}")
+
+
+def get_disagg_aggregates_by_digest_vs30_nloc0(
+    location_codes: list[str],
+    vs30s: list[int],
+    hazard_model: str,
+    imts: list[str],
+    aggs: list[str],
+    target_aggrs: list[str],
+    probabilities: list[ProbabilityEnum],
+    bins_digest: str,
+    dataset_uri: Optional[str] = None,
+) -> Iterator[AggregatedDisagg]:
+    """
+    Retrieves aggregated disaggregations using bins_digest, vs30, and nloc_0 partition pruning.
+
+    Args:
+      location_codes (list): List of location codes.
+      vs30s (list): List of VS30 values.
+      hazard_model: the hazard model id.
+      imts (list): List of intensity measure types.
+      aggs (list): List of aggregation types.
+      target_aggrs (list): List of target hazard-curve aggregation types.
+      probabilities (list): List of ProbabilityEnum members.
+      bins_digest: pre-computed bins compatibility digest.
+      dataset_uri: optional URI for the dataset. Defaults to the THS_DATASET_DISAGG_AGGR_URI env var.
+
+    Yields:
+      AggregatedDisagg: An object containing disaggregation aggregate data.
+
+    Raises:
+      RuntimeWarning: describing any dataset partitions that could not be opened.
+    """
+    log.debug(f"> get_disagg_aggregates_by_digest_vs30_nloc0({location_codes}, {vs30s},...)")
+    t0 = dt.datetime.now()
+
+    dataset_exceptions = []
+    prob_names = [p.name for p in probabilities]
+
+    for hash_location_code in get_hashes(location_codes, 1):
+        log.debug("hash_key %s" % hash_location_code)
+        hash_locs = list(
+            filter(
+                lambda loc: downsample_code(loc, 1) == hash_location_code,
+                location_codes,
+            )
+        )
+        nloc_001_locs = [downsample_code(loc, 0.001) for loc in hash_locs]
+
+        count = 0
+
+        for hloc, vs30 in itertools.product(hash_locs, vs30s):
+            try:
+                dataset = get_disagg_aggr_dataset_digest_vs30_nloc0(bins_digest, vs30, hloc, dataset_uri)
+            except Exception as exc:
+                dataset_exceptions.append(str(exc))
+                continue
+
+            t1 = dt.datetime.now()
+            flt = (
+                (pc.field("aggr").isin(aggs))
+                & (pc.field("target_aggr").isin(target_aggrs))
+                & (pc.field("nloc_001").isin(nloc_001_locs))
+                & (pc.field("imt").isin(imts))
+                & (pc.field("hazard_model_id") == hazard_model)
+                & (pc.field("probability").isin(prob_names))
+            )
+            log.debug(f"filter: {flt}")
+            table = dataset.to_table(filter=flt)
+            t2 = dt.datetime.now()
+            log.debug(f"to_table for filter took {(t2 - t1).total_seconds()} seconds.")
+
+            df = table.to_pandas()
+            for row_dict in df.to_dict(orient="records"):
+                count += 1
+                row_dict["probability"] = ProbabilityEnum[row_dict["probability"]]
+                row_dict["bins_digest"] = bins_digest
+                row_dict["vs30"] = vs30
+                row_dict["nloc_0"] = downsample_code(hloc, 1.0)
+                yield AggregatedDisagg.model_construct(**row_dict)
+
+        log.debug(f"Executed dataset query for {count} disaggs in {(dt.datetime.now() - t0).total_seconds()} seconds.")
 
     if dataset_exceptions:  # pragma: no branch
         raise RuntimeWarning(f"Dataset errors: {dataset_exceptions}")

--- a/uv.lock
+++ b/uv.lock
@@ -10,7 +10,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-04-23T20:09:48.024946053Z"
+exclude-newer = "2026-04-27T21:52:08.984381697Z"
 exclude-newer-span = "P1W"
 
 [options.exclude-newer-package]
@@ -4979,7 +4979,7 @@ wheels = [
 
 [[package]]
 name = "toshi-hazard-store"
-version = "1.5.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "geopandas" },


### PR DESCRIPTION
closes #160 

- Store disaggregation aggregates as PyArrow parquet datasets (`DisaggregationAggregate` model, schema, writer)                                                                                          
- Query disaggregation aggregates via `toshi_hazard_store.query.get_disagg_aggregates()` with naive/d1/d2 strategies                                                                                     
- `DisaggregationAggregate.to_ndarray()` to reshape flat `disagg_values` into an N-D array                                                                                                               
- `THS_DATASET_DISAGG_AGGR_URI` environment variable for disagg aggregate dataset location                                                                                                               
- `_bins_digest_from_dict()` shared helper for computing the bins compatibility digest from a `disagg_bins` dict                                                                                         
- Documentation for disaggregation aggregates: updated `docs/domain_model/disaggregation_models.md` and query Quick Start                                                                                
- `dataset_cache.py` refactored: shared `_open_partitioned_dataset()` helper used by all six dataset accessors (hazard + disagg)       